### PR TITLE
Rebrand to BetterStreamflix (dskja)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
-<h1 align="center">Streamflix Reborn</h1>
+<h1 align="center">BetterStreamflix</h1>
 
 <p align="center">
   <img src="./app/src/main/res/mipmap-xxxhdpi/ic_launcher.png" height="100px" />
   <br />
-  <strong>🔄 Reborn Version</strong> - Community continuation of the original Streamflix project
+  <strong>Maintained by <a href="https://github.com/dskja">dskja</a></strong>
   <br />
-  An open-source Android TV and mobile app for educational streaming interface, made with Android Studio, in Kotlin
+  An actively maintained fork of Streamflix with extra fixes, providers and UX improvements for Android TV and mobile.
   <br />
-  <a href="https://github.com/streamflix-reborn2/streamflix/releases/latest">
+  <a href="https://github.com/dskja/BetterStreamflix/releases/latest">
     <strong>Download app »</strong>
   </a>
   <br />
   <br />
-  <a href="https://github.com/streamflix-reborn2/streamflix/issues">Report Bug</a>
+  <a href="https://t.me/BetterStreamflix">Telegram channel</a>
   ·
-  <a href="https://github.com/streamflix-reborn2/streamflix/issues">Request Feature</a>
+  <a href="https://github.com/dskja/BetterStreamflix/issues">Report Bug</a>
+  ·
+  <a href="https://github.com/dskja/BetterStreamflix/issues">Request Feature</a>
 </p>
 
 <details>
   <summary>Table of Contents</summary>
 
 - [About the project](#about-the-project)
-  - [What is Streamflix Reborn?](#-what-is-streamflix-reborn2)
+  - [What is BetterStreamflix?](#what-is-betterstreamflix)
   - [Features](#features)
   - [Built with](#built-with)
 - [Getting started](#getting-started)
@@ -30,30 +32,25 @@
 - [Development](#development)
 - [Contributing](#contributing)
 - [Legal Disclaimer](#legal-disclaimer)
-- [Credits & Authors](#credits--authors)
+- [Credits &amp; Authors](#credits--authors)
 - [License](#license)
 </details>
 
 ## About the project
 
 <p align="center">
-  <img src="./.github/docs/screenshot.png" alt="Streamflix Preview">
+  <img src="./.github/docs/screenshot.png" alt="BetterStreamflix Preview">
 </p>
 
-**Streamflix Reborn** is an independent continuation of the original Streamflix project created by [Lory-Stan TANASI](https://github.com/stantanasi). This reborn version maintains the same educational purpose and functionality while ensuring continued development and support.
+**BetterStreamflix** is maintained by **[dskja](https://github.com/dskja)**. It builds on the community Streamflix Reborn project and the original Streamflix app, with ongoing fixes and improvements.
 
-### 🔄 What is Streamflix Reborn?
+### What is BetterStreamflix?
 
-- **Independent Continuation**: This is an independent continuation of the original Streamflix project
-- **Same Vision**: Maintains the original educational and open-source philosophy
-- **Enhanced Support**: Continued development and bug fixes by an independent developer
-- **Respectful Fork**: Built with full respect for the original creator's work
+- **Active fork**: Continued fixes for providers, TV playback and settings
+- **Same educational purpose**: Open-source Android TV / mobile streaming UI
+- **Community channel**: Updates and discussion on [Telegram @BetterStreamflix](https://t.me/BetterStreamflix)
 
-Streamflix Reborn is an open-source Android TV and mobile app that provides a user interface for accessing publicly available streaming content from various third-party providers.
-
-This app is designed for educational purposes and personal use only. Users are responsible for ensuring they have proper authorization to access any content they view through this application.
-
-The interface aggregates content from multiple sources and provides a convenient way to browse available streaming options.
+This app provides a user interface for accessing publicly available streaming content from various third-party providers. It is designed for educational purposes and personal use only. Users are responsible for ensuring they have proper authorization to access any content they view through this application.
 
 ### Features
 
@@ -61,22 +58,21 @@ The interface aggregates content from multiple sources and provides a convenient
 - Aggregates content from multiple third-party providers
 - No account required for the app interface
 - Educational and personal use only
-- Optimized UI & UX
+- Optimized UI &amp; UX for mobile and Android TV
 - Multiple providers
 - Resume from last playback position
-- In-app update
+- In-app update from this repository’s releases
 
 ### Built with
 
 - [Android Studio](https://developer.android.com/studio)
 - [Kotlin](https://kotlinlang.org)
 - [Retrofit](https://square.github.io/retrofit)
-- [ExoPlayer](https://exoplayer.dev)
+- [ExoPlayer / Media3](https://developer.android.com/media/media3)
 - Leanback
 - Coroutines
 - MVVM Architecture
 - Android Architecture Components
-
 
 ## Getting started
 
@@ -86,35 +82,34 @@ Install [Android Studio](https://developer.android.com/studio)
 
 ### Setup
 
-1. Clone the project to your local machine
+1. Clone the project
 
 ```bash
-git clone https://github.com/streamflix-reborn2/streamflix.git
+git clone https://github.com/dskja/BetterStreamflix.git
 ```
 
 2. Open the project in Android Studio
 
 ## Development
 
-1. Select the device that you want to run the app
-
+1. Select the device that you want to run the app on
 2. Click **Run**
 
 ## Contributing
 
-Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+Contributions are welcome.
 
 1. Fork the project
 2. Create your feature branch (`git checkout -b feature/amazing-feature`)
 3. Commit your changes (`git commit -m 'feat: add some amazing feature'`)
 4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a pull request
+5. Open a pull request against [dskja/BetterStreamflix](https://github.com/dskja/BetterStreamflix)
 
 ## Legal Disclaimer
 
 **IMPORTANT: This application is for educational and personal use only.**
 
-- Streamflix does not host, store, or distribute any copyrighted content
+- BetterStreamflix does not host, store, or distribute any copyrighted content
 - All content is sourced from third-party providers and websites
 - Users are solely responsible for ensuring they have legal rights to access any content
 - The developers do not endorse or encourage copyright infringement
@@ -123,36 +118,24 @@ Contributions are what make the open source community such an amazing place to l
 - This app functions as a search engine aggregator only
 - No copyrighted material is stored on our servers
 
-## Legal Notice
+## Credits &amp; Authors
 
-This application is provided "as is" for educational purposes. The developers:
-- Do not claim ownership of any content
-- Do not profit from copyrighted material
-- Do not control third-party content providers
-- Encourage users to support content creators through legal means
-- Recommend using official streaming services when available
+### Maintainer
+- **[dskja](https://github.com/dskja)** — BetterStreamflix
+- Telegram: [t.me/BetterStreamflix](https://t.me/BetterStreamflix)
 
-## Credits & Authors
+### Upstream
+- **[streamflix-reborn2/streamflix](https://github.com/streamflix-reborn2/streamflix)** — Streamflix Reborn community continuation
 
 ### Original Creator
-- **[Lory-Stan TANASI](https://github.com/stantanasi)** - Original Streamflix project creator
-
-### Reborn Development
-- **Independent Developer** - Streamflix Reborn maintainer
-- **Special thanks** to the original creator for the excellent foundation
+- **[Lory-Stan TANASI](https://github.com/stantanasi)** — Original Streamflix project
 
 ## License
 
-This project is licensed under the `Apache-2.0` License - see the [LICENSE](LICENSE) file for details
+This project is licensed under the `Apache-2.0` License — see the [LICENSE](LICENSE) file for details.
 
-### Original Project
 <p align="center">
-  <br />
-  © 2022 Lory-Stan TANASI. All rights reserved
-</p>
-
-### Reborn Project
-<p align="center">
-  <br />
-  © 2025 Streamflix Reborn. Built with respect for the original work.
+  © 2022 Lory-Stan TANASI — original Streamflix<br />
+  Built with respect for Streamflix Reborn and the original work<br />
+  © 2026 dskja / BetterStreamflix
 </p>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
     properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
     defaultConfig {
-        applicationId "com.streamflixreborn.streamflix"
+        applicationId "com.dskja.betterstreamflix"
         minSdk 21
         targetSdk 35
         versionCode 160

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Streamflix - debug</string>
+    <string name="app_name">BetterStreamflix - debug</string>
 </resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,6 +84,8 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
 
+                <data android:scheme="betterstreamflix"
+                        android:host="resolve"/>
                 <data android:scheme="streamflix"
                         android:host="resolve"/>
             </intent-filter>

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
@@ -352,7 +352,7 @@ class PlayerTvFragment : Fragment() {
                             }
 
                             val deepLink =
-                                "streamflix://resolve?ws=${Uri.encode(wsUrl)}&token=${Uri.encode(session.token)}"
+                                "betterstreamflix://resolve?ws=${Uri.encode(wsUrl)}&token=${Uri.encode(session.token)}"
                             val httpPort = startHttpLandingServer(deepLink)
                             val qrContent = if (httpPort != -1) {
                                 val host = BypassWebSocketEndpointHelper.getLocalIpv4Address()

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/SettingsMobileFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/SettingsMobileFragment.kt
@@ -127,7 +127,7 @@ class SettingsMobileFragment : PreferenceFragmentCompat() {
 
         val rawValue = result.data?.getStringExtra(QrScannerActivity.EXTRA_QR_VALUE).orEmpty()
         val uri = rawValue
-            .takeIf { it.startsWith("streamflix://resolve") }
+            .takeIf { it.startsWith("betterstreamflix://resolve") || it.startsWith("streamflix://resolve") }
             ?.let(Uri::parse)
 
         if (uri == null) {
@@ -460,7 +460,7 @@ class SettingsMobileFragment : PreferenceFragmentCompat() {
             startActivity(
                 Intent(
                     Intent.ACTION_VIEW,
-                    Uri.parse("https://github.com/streamflix-reborn2/streamflix")
+                    Uri.parse("https://github.com/dskja/BetterStreamflix")
                 )
             )
             true
@@ -468,11 +468,11 @@ class SettingsMobileFragment : PreferenceFragmentCompat() {
 
         findPreference<Preference>("p_settings_telegram")?.setOnPreferenceClickListener {
             try {
-                val tgIntent = Intent(Intent.ACTION_VIEW, Uri.parse("tg://resolve?domain=streamflixreborn"))
+                val tgIntent = Intent(Intent.ACTION_VIEW, Uri.parse("tg://resolve?domain=BetterStreamflix"))
                 startActivity(tgIntent)
             } catch (e: Exception) {
                 Toast.makeText(requireContext(), "Telegram not found.", Toast.LENGTH_SHORT).show()
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://t.me/streamflixreborn"))
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://t.me/BetterStreamflix"))
                 startActivity(intent)
             }
             true

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/SettingsTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/SettingsTvFragment.kt
@@ -557,7 +557,7 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
             startActivity(
                 Intent(
                     Intent.ACTION_VIEW,
-                    Uri.parse("https://github.com/streamflix-reborn2/streamflix")
+                    Uri.parse("https://github.com/dskja/BetterStreamflix")
                 )
             )
             true
@@ -565,11 +565,11 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
 
         findPreference<Preference>("p_settings_telegram")?.setOnPreferenceClickListener {
             try {
-                val tgIntent = Intent(Intent.ACTION_VIEW, Uri.parse("tg://resolve?domain=streamflixreborn"))
+                val tgIntent = Intent(Intent.ACTION_VIEW, Uri.parse("tg://resolve?domain=BetterStreamflix"))
                 startActivity(tgIntent)
             } catch (e: Exception) {
                 Toast.makeText(requireContext(), "Telegram not found.", Toast.LENGTH_SHORT).show()
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://t.me/streamflixreborn"))
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://t.me/BetterStreamflix"))
                 startActivity(intent)
             }
             true
@@ -1166,7 +1166,7 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
                     val values = ContentValues().apply {
                         put(MediaStore.Downloads.DISPLAY_NAME, fileName)
                         put(MediaStore.Downloads.MIME_TYPE, "application/json")
-                        put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/StreamFlix")
+                        put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/BetterStreamflix")
                     }
                     val uri = requireContext().contentResolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
                         ?: error("Unable to create download entry")
@@ -1176,7 +1176,7 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
 
                     Toast.makeText(
                         requireContext(),
-                        getString(R.string.backup_export_saved_to, "Downloads/StreamFlix/$fileName"),
+                        getString(R.string.backup_export_saved_to, "Downloads/BetterStreamflix/$fileName"),
                         Toast.LENGTH_LONG
                     ).show()
                 }.onFailure { error ->
@@ -1233,7 +1233,7 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
                     val values = ContentValues().apply {
                         put(MediaStore.Downloads.DISPLAY_NAME, fileName)
                         put(MediaStore.Downloads.MIME_TYPE, "application/zip")
-                        put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/StreamFlix")
+                        put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/BetterStreamflix")
                     }
                     val uri = requireContext().contentResolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
                         ?: error("Unable to create download entry")
@@ -1243,7 +1243,7 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
 
                     Toast.makeText(
                         requireContext(),
-                        getString(R.string.backup_export_saved_to, "Downloads/StreamFlix/$fileName"),
+                        getString(R.string.backup_export_saved_to, "Downloads/BetterStreamflix/$fileName"),
                         Toast.LENGTH_LONG
                     ).show()
                 }.onFailure { error ->

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/SupabaseSettingsController.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/SupabaseSettingsController.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.launch
 
 object SupabaseSettingsController {
     private const val SETUP_INSTRUCTIONS_URL =
-        "https://github.com/streamflix-reborn2/streamflix/blob/main/supabase_installation.md"
+        "https://github.com/dskja/BetterStreamflix/blob/main/supabase_installation.md"
 
     fun bind(
         fragment: Fragment,

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/about/SettingsAboutMobileFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/about/SettingsAboutMobileFragment.kt
@@ -1,5 +1,7 @@
 package com.streamflixreborn.streamflix.fragments.settings.about
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -19,5 +21,18 @@ class SettingsAboutMobileFragment : PreferenceFragmentCompat() {
             summary = getString(R.string.settings_about_version_name, BuildConfig.VERSION_NAME)
         }
 
+        findPreference<Preference>("p_settings_github")?.setOnPreferenceClickListener {
+            openUrl("https://github.com/dskja/BetterStreamflix")
+            true
+        }
+
+        findPreference<Preference>("p_settings_upstream")?.setOnPreferenceClickListener {
+            openUrl("https://github.com/streamflix-reborn2/streamflix")
+            true
+        }
+    }
+
+    private fun openUrl(url: String) {
+        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
     }
 }

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/about/SettingsAboutTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/about/SettingsAboutTvFragment.kt
@@ -1,5 +1,7 @@
 package com.streamflixreborn.streamflix.fragments.settings.about
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.leanback.preference.LeanbackPreferenceFragmentCompat
 import androidx.preference.Preference
@@ -19,5 +21,18 @@ class SettingsAboutTvFragment : LeanbackPreferenceFragmentCompat() {
             summary = getString(R.string.settings_about_version_name, BuildConfig.VERSION_NAME)
         }
 
+        findPreference<Preference>("p_settings_github")?.setOnPreferenceClickListener {
+            openUrl("https://github.com/dskja/BetterStreamflix")
+            true
+        }
+
+        findPreference<Preference>("p_settings_upstream")?.setOnPreferenceClickListener {
+            openUrl("https://github.com/streamflix-reborn2/streamflix")
+            true
+        }
+    }
+
+    private fun openUrl(url: String) {
+        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
     }
 }

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/BypassHttpLandingServer.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/BypassHttpLandingServer.kt
@@ -10,7 +10,7 @@ import java.nio.charset.StandardCharsets
  *
  * Phone cameras often cannot open `streamflix://` deep links (they search Google instead).
  * Encoding an `http://TV-IP:port/resolve?...` URL in the QR lets the camera open a page that
- * bridges into the StreamFlix app and explains the in-app scanner fallback.
+ * bridges into the BetterStreamflix app and explains the in-app scanner fallback.
  */
 class BypassHttpLandingServer(
     port: Int,
@@ -49,7 +49,7 @@ class BypassHttpLandingServer(
     private fun buildDeepLink(ws: String, token: String): String {
         val encodedWs = URLEncoder.encode(ws, StandardCharsets.UTF_8.name())
         val encodedToken = URLEncoder.encode(token, StandardCharsets.UTF_8.name())
-        return "streamflix://resolve?ws=$encodedWs&token=$encodedToken"
+        return "betterstreamflix://resolve?ws=$encodedWs&token=$encodedToken"
     }
 
     private fun htmlResponse(body: String): Response {
@@ -70,7 +70,7 @@ class BypassHttpLandingServer(
               <meta charset="utf-8"/>
               <meta name="viewport" content="width=device-width, initial-scale=1"/>
               <meta http-equiv="refresh" content="0;url=$safeDeepLink"/>
-              <title>StreamFlix TV Bypass</title>
+              <title>BetterStreamflix TV Bypass</title>
               <style>
                 body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;margin:0;padding:24px;background:#111;color:#f5f5f5;line-height:1.45}
                 .card{max-width:520px;margin:0 auto;background:#1c1c1c;border-radius:16px;padding:20px}
@@ -85,15 +85,15 @@ class BypassHttpLandingServer(
             </head>
             <body>
               <div class="card">
-                <h1>StreamFlix TV-Captcha</h1>
-                <p><strong>DE:</strong> Dies ist kein SerienStream-Link. Öffne die Captcha-Seite in der <strong>StreamFlix-App</strong>.</p>
+                <h1>BetterStreamflix TV-Captcha</h1>
+                <p><strong>DE:</strong> Dies ist kein SerienStream-Link. Öffne die Captcha-Seite in der <strong>BetterStreamflix-App</strong>.</p>
                 <ol>
-                  <li>Tippe unten auf „In StreamFlix öffnen“.</li>
+                  <li>Tippe unten auf „In BetterStreamflix öffnen“.</li>
                   <li>Oder in der App: Einstellungen → <strong>TV-Bypass-QR scannen</strong>.</li>
                   <li>Captcha lösen → <strong>Weiter</strong>. Der QR auf dem TV schließt sich automatisch.</li>
                 </ol>
-                <p class="muted"><strong>EN:</strong> Do not use a normal camera search. Open StreamFlix on this phone, then use Settings → Scan TV bypass QR if the button below does nothing.</p>
-                <p><a class="button" href="$safeDeepLink">In StreamFlix öffnen / Open in StreamFlix</a></p>
+                <p class="muted"><strong>EN:</strong> Do not use a normal camera search. Open BetterStreamflix on this phone, then use Settings → Scan TV bypass QR if the button below does nothing.</p>
+                <p><a class="button" href="$safeDeepLink">In BetterStreamflix öffnen / Open in BetterStreamflix</a></p>
                 <p class="muted">Deep link:<br/><code>$safeDeepLink</code></p>
               </div>
               <script>

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/InAppUpdater.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/InAppUpdater.kt
@@ -14,8 +14,8 @@ import kotlin.math.max
 
 object InAppUpdater {
 
-    private const val GITHUB_OWNER = "streamflix-reborn2"
-    private const val GITHUB_REPO = "streamflix"
+    private const val GITHUB_OWNER = "dskja"
+    private const val GITHUB_REPO = "BetterStreamflix"
 
     private data class Version(val name: String) : Comparable<Version> {
         override operator fun compareTo(other: Version): Int {

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/WebSocketBypassTestHelper.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/WebSocketBypassTestHelper.kt
@@ -28,7 +28,7 @@ object WebSocketBypassTestHelper {
         val token = UUID.randomUUID().toString()
 
         activeServer.registerSession(token, url)
-        val deepLink = "streamflix://resolve?ws=${Uri.encode(wsUrl)}&token=$token"
+        val deepLink = "betterstreamflix://resolve?ws=${Uri.encode(wsUrl)}&token=$token"
 
         return Session(
             token = token,

--- a/app/src/main/mobile/AndroidManifest.xml
+++ b/app/src/main/mobile/AndroidManifest.xml
@@ -55,6 +55,7 @@
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="betterstreamflix" android:host="resolve"/>
                 <data android:scheme="streamflix" android:host="resolve"/>
             </intent-filter>
         </activity>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="app_name">ستريم فليكس</string>
+	<string name="app_name">BetterStreamflix</string>
 
 	<string name="loading_error_title">حدث خطأ</string>
 	<string name="loading_error_retry">إعادة المحاولة</string>
@@ -368,7 +368,7 @@
     <string name="settings_category_streamingcommunity_dnsOverHttps">استخدام DNS آمن</string>
     <string name="settings_scan_resolver_qr_title">مسح رمز تجاوز التلفاز</string>
     <string name="settings_scan_resolver_qr_summary">افتح الكاميرا وامسح رمز QR المعروض على التلفاز</string>
-    <string name="settings_scan_resolver_invalid_qr">رمز QR هذا ليس رابط تجاوز StreamFlix.</string>
+    <string name="settings_scan_resolver_invalid_qr">رمز QR هذا ليس رابط تجاوز BetterStreamflix.</string>
     <string name="settings_scan_resolver_failed">تعذر تشغيل ماسح QR على هذا الجهاز.</string>
     <string name="settings_category_provider_url_manual">إدخال يدوي</string>
     <string name="settings_autoplay_buffer_title">مهلة التشغيل التلقائي</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="app_name">Streamflix</string>
+    <string name="app_name">BetterStreamflix</string>
 
     <string name="loading_error_title">Ein Fehler ist aufgetreten</string>
     <string name="loading_error_retry">Erneut versuchen</string>
@@ -231,7 +231,7 @@
     <string name="settings_about_version">Version</string>
     <string name="settings_about_version_name">Version %s</string>
     <string name="settings_help">Hilfe</string>
-    <string name="settings_telegram">Telegram‑Gruppe</string>
+    <string name="settings_telegram">Telegram-Kanal</string>
     <string name="settings_category_streamingcommunity">StreamingCommunity - Einstellungen</string>
     <string name="settings_category_streamingcommunity_domain">StreamingCommunity - Domain-Name</string>
     <string name="settings_streamingcommunity_domain_reset">Domain zurücksetzen</string>
@@ -386,14 +386,14 @@
     <string name="settings_category_poseidon">Poseidonhd2-Einstellungen</string>
     <string name="settings_category_poseidon_domain">Poseidonhd2-Domainname</string>
     <string name="settings_scan_resolver_qr_title">TV-Bypass-QR scannen</string>
-    <string name="settings_scan_resolver_qr_summary">Nutze diesen StreamFlix-Scanner für den QR auf dem TV — die normale Handykamera öffnet oft Google statt der App</string>
+    <string name="settings_scan_resolver_qr_summary">Nutze diesen BetterStreamflix-Scanner für den QR auf dem TV — die normale Handykamera öffnet oft Google statt der App</string>
     <string name="player_bypass_qr_title">Captcha am Handy lösen</string>
-    <string name="player_bypass_qr_instructions">1. Öffne StreamFlix am Handy (gleiches WLAN wie der TV).\n2. Einstellungen → TV-Bypass-QR scannen (nicht nur die Systemkamera).\n3. Captcha lösen, dann Weiter tippen. Dieser Dialog schließt sich automatisch.</string>
+    <string name="player_bypass_qr_instructions">1. Öffne BetterStreamflix am Handy (gleiches WLAN wie der TV).\n2. Einstellungen → TV-Bypass-QR scannen (nicht nur die Systemkamera).\n3. Captcha lösen, dann Weiter tippen. Dieser Dialog schließt sich automatisch.</string>
     <string name="player_bypass_qr_endpoint">TV-Endpunkt: %1$s</string>
     <string name="player_bypass_qr_emulator_note">Emulator erkannt: Setze unter TV-Einstellungen „Bypass advertised host“ auf die LAN-IP deines PCs, damit das Handy dieses Gerät erreicht.</string>
-    <string name="player_bypass_retry_needed">Für diesen Titel ist weiterhin ein Captcha nötig. Scanne den QR erneut mit StreamFlix.</string>
+    <string name="player_bypass_retry_needed">Für diesen Titel ist weiterhin ein Captcha nötig. Scanne den QR erneut mit BetterStreamflix.</string>
     <string name="player_bypass_no_lan_ip">Keine LAN-IP für den QR gefunden. Setze unter Einstellungen „Bypass advertised host“ (z. B. 192.168.x.x).</string>
-    <string name="settings_scan_resolver_invalid_qr">Dieser QR-Code ist kein StreamFlix-Bypass-Link.</string>
+    <string name="settings_scan_resolver_invalid_qr">Dieser QR-Code ist kein BetterStreamflix-Bypass-Link.</string>
     <string name="settings_scan_resolver_failed">QR-Scanner konnte auf diesem Gerät nicht gestartet werden.</string>
     <string name="settings_category_provider_url_manual">Manuell eingeben</string>
     <string name="player_skip_intro">Intro überspringen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Streamflix</string>
+    <string name="app_name">BetterStreamflix</string>
 
     <string name="loading_error_title">Ha ocurrido un error</string>
     <string name="loading_error_retry">Reintentar</string>
@@ -240,7 +240,7 @@
     <string name="settings_version_mobile">Versión para móviles</string>
     <string name="settings_about_version_name">Versión %s</string>
     <string name="settings_help">Ayuda</string>
-    <string name="settings_telegram">Grupo de Telegram</string>
+    <string name="settings_telegram">Canal de Telegram</string>
     <string name="settings_refresh_cache_title">Actualizar caché desde la base de datos</string>
     <string name="settings_refresh_cache_summary">Recargar el historial de visualización y los datos de la app desde la base de datos</string>
     <string name="settings_refresh_cache_confirm">¿Actualizar la caché?</string>
@@ -263,8 +263,8 @@
     <string name="settings_category_network_title">Conexión y servicios</string>
     <string name="settings_screen_network_summary">DNS, bypass para TV y claves de servicios de subtitulos</string>
     <string name="settings_scan_resolver_qr_title">Escanear QR de bypass TV</string>
-    <string name="settings_scan_resolver_qr_summary">Usa el escáner de StreamFlix para el QR de la TV — la cámara del sistema a menudo abre Google en lugar de la app</string>
-    <string name="settings_scan_resolver_invalid_qr">Este código QR no es un enlace de bypass de StreamFlix.</string>
+    <string name="settings_scan_resolver_qr_summary">Usa el escáner de BetterStreamflix para el QR de la TV — la cámara del sistema a menudo abre Google en lugar de la app</string>
+    <string name="settings_scan_resolver_invalid_qr">Este código QR no es un enlace de bypass de BetterStreamflix.</string>
     <string name="settings_scan_resolver_failed">No se pudo iniciar el escáner QR en este dispositivo.</string>
     <string name="settings_scan_resolver_camera_permission_denied">Se necesita permiso de la cámara para escanear el codigo QR.</string>
     <string name="settings_scan_resolver_camera_unavailable">No hay una cámara disponible en este dispositivo.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="app_name">Streamflix</string>
+    <string name="app_name">BetterStreamflix</string>
 
     <string name="loading_error_title">Une erreur est survenue</string>
     <string name="loading_error_retry">Réessayer</string>
@@ -231,7 +231,7 @@
     <string name="settings_about_version">Version</string>
     <string name="settings_about_version_name">Version %s</string>
     <string name="settings_help">Aide</string>
-    <string name="settings_telegram">Groupe Telegram</string>
+    <string name="settings_telegram">Canal Telegram</string>
     <string name="settings_category_streamingcommunity">Paramètres StreamingCommunity</string>
     <string name="settings_category_streamingcommunity_domain">Nom de domaine StreamingCommunity</string>
     <string name="settings_streamingcommunity_domain_reset">Réinitialiser le domaine</string>
@@ -425,8 +425,8 @@
     <string name="settings_category_poseidon">Paramètres Poseidonhd2</string>
     <string name="settings_category_poseidon_domain">Nom de domaine Poseidonhd2</string>
     <string name="settings_scan_resolver_qr_title">Scanner le QR de contournement TV</string>
-    <string name="settings_scan_resolver_qr_summary">Utilise le scanner StreamFlix pour le QR affiché sur la TV — l\'appareil photo système ouvre souvent Google au lieu de l\'app</string>
-    <string name="settings_scan_resolver_invalid_qr">Ce code QR n\'est pas un lien de contournement StreamFlix.</string>
+    <string name="settings_scan_resolver_qr_summary">Utilise le scanner BetterStreamflix pour le QR affiché sur la TV — l\'appareil photo système ouvre souvent Google au lieu de l\'app</string>
+    <string name="settings_scan_resolver_invalid_qr">Ce code QR n\'est pas un lien de contournement BetterStreamflix.</string>
     <string name="settings_scan_resolver_failed">Impossible de démarrer le scanner QR sur cet appareil.</string>
     <string name="settings_category_provider_url_manual">Saisir manuellement</string>
     <string name="player_skip_intro">Passer l\'intro</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="app_name">Streamflix</string>
+    <string name="app_name">BetterStreamflix</string>
 
     <string name="loading_error_title">Si è verificato un errore</string>
     <string name="loading_error_retry">Riprova</string>
@@ -230,7 +230,7 @@
     <string name="settings_version_mobile">Versione Mobile</string>
     <string name="settings_about_version_name">Versione %s</string>
     <string name="settings_help">Aiuto</string>
-    <string name="settings_telegram">Gruppo Telegram</string>
+    <string name="settings_telegram">Canale Telegram</string>
     <string name="settings_category_streamingcommunity">Impostazioni StreamingCommunity</string>
     <string name="settings_category_streamingcommunity_domain">Nome di dominio StreamingCommunity</string>
     <string name="settings_streamingcommunity_domain_reset">Reimposta dominio</string>
@@ -408,8 +408,8 @@
     <string name="settings_category_poseidon">Impostazioni Poseidonhd2</string>
     <string name="settings_category_poseidon_domain">Nome di dominio Poseidonhd2</string>
     <string name="settings_scan_resolver_qr_title">Scansiona QR bypass TV</string>
-    <string name="settings_scan_resolver_qr_summary">Usa lo scanner StreamFlix per il QR sulla TV — la fotocamera di sistema spesso apre Google invece dell\'app</string>
-    <string name="settings_scan_resolver_invalid_qr">Questo codice QR non è un link di bypass StreamFlix.</string>
+    <string name="settings_scan_resolver_qr_summary">Usa lo scanner BetterStreamflix per il QR sulla TV — la fotocamera di sistema spesso apre Google invece dell\'app</string>
+    <string name="settings_scan_resolver_invalid_qr">Questo codice QR non è un link di bypass BetterStreamflix.</string>
     <string name="settings_scan_resolver_failed">Impossibile avviare lo scanner QR su questo dispositivo.</string>
     <string name="settings_category_provider_url_manual">Inserisci manualmente</string>
     <string name="player_skip_intro">Salta intro</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Streamflix</string>
+    <string name="app_name">BetterStreamflix</string>
 
     <string name="loading_error_title">Wystapil blad</string>
     <string name="loading_error_retry">Sprobuj ponownie</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="app_name">Streamflix</string>
+    <string name="app_name">BetterStreamflix</string>
 
     <string name="loading_error_title">An error occurred</string>
     <string name="loading_error_retry">Retry</string>
@@ -253,12 +253,19 @@
     <string name="player_settings_servers_label">Servers</string>
 
     <string name="settings_about">About</string>
+    <string name="settings_telegram_channel">Telegram channel</string>
+    <string name="settings_about_maintainer">Maintained by dskja</string>
+    <string name="settings_about_credits">Credits</string>
+    <string name="settings_about_credits_summary">Based on Streamflix Reborn (upstream) and the original Streamflix by Lory-Stan TANASI</string>
+    <string name="settings_about_upstream">Upstream project</string>
+    <string name="settings_github">GitHub</string>
+
     <string name="settings_about_version">Version</string>
     <string name="settings_version_tv">Version TV</string>
     <string name="settings_version_mobile">Version Mobile</string>
     <string name="settings_about_version_name">Version %s</string>
     <string name="settings_help">Help</string>
-    <string name="settings_telegram">Telegram group</string>
+    <string name="settings_telegram">Telegram channel</string>
     <string name="settings_refresh_cache_title">Refresh cache from database</string>
     <string name="settings_refresh_cache_summary">Reload watch history and app data from database</string>
     <string name="settings_refresh_cache_confirm">Refresh cache?</string>
@@ -291,14 +298,14 @@
     <string name="settings_category_network_title">Connection &amp; Services</string>
     <string name="settings_screen_network_summary">DNS, TV bypass tools and subtitle service keys</string>
     <string name="settings_scan_resolver_qr_title">Scan TV bypass QR</string>
-    <string name="settings_scan_resolver_qr_summary">Use this StreamFlix scanner for the QR on TV — a normal phone camera often opens Google instead of the app</string>
+    <string name="settings_scan_resolver_qr_summary">Use this BetterStreamflix scanner for the QR on TV — a normal phone camera often opens Google instead of the app</string>
     <string name="player_bypass_qr_title">Solve captcha on phone</string>
-    <string name="player_bypass_qr_instructions">1. Open StreamFlix on your phone (same Wi‑Fi as the TV).\n2. Go to Settings → Scan TV bypass QR (do not rely on the stock camera alone).\n3. Solve the captcha, then tap Continue. This dialog closes automatically.</string>
+    <string name="player_bypass_qr_instructions">1. Open BetterStreamflix on your phone (same Wi‑Fi as the TV).\n2. Go to Settings → Scan TV bypass QR (do not rely on the stock camera alone).\n3. Solve the captcha, then tap Continue. This dialog closes automatically.</string>
     <string name="player_bypass_qr_endpoint">TV endpoint: %1$s</string>
     <string name="player_bypass_qr_emulator_note">Emulator detected: set “Bypass advertised host” in TV settings to your PC LAN IP so the phone can reach this device.</string>
-    <string name="player_bypass_retry_needed">Captcha is still required for this title. Scan the QR again with StreamFlix.</string>
+    <string name="player_bypass_retry_needed">Captcha is still required for this title. Scan the QR again with BetterStreamflix.</string>
     <string name="player_bypass_no_lan_ip">No LAN IP found for the QR. Set “Bypass advertised host” in Settings (e.g. 192.168.x.x).</string>
-    <string name="settings_scan_resolver_invalid_qr">This QR code is not a StreamFlix bypass link.</string>
+    <string name="settings_scan_resolver_invalid_qr">This QR code is not a BetterStreamflix bypass link.</string>
     <string name="settings_scan_resolver_failed">Unable to start QR scanner on this device.</string>
     <string name="settings_scan_resolver_camera_permission_denied">Camera permission is required to scan the QR code.</string>
     <string name="settings_scan_resolver_camera_unavailable">No camera is available on this device.</string>

--- a/app/src/main/res/xml/settings_about_mobile.xml
+++ b/app/src/main/res/xml/settings_about_mobile.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.preference.PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <Preference
@@ -8,5 +9,29 @@
         app:title="@string/settings_about_version"
         tools:summary="@string/settings_about_version_name" />
 
+    <Preference
+        app:iconSpaceReserved="false"
+        app:key="p_settings_about_maintainer"
+        app:title="@string/settings_about_maintainer"
+        android:selectable="false" />
+
+    <Preference
+        app:iconSpaceReserved="false"
+        app:key="p_settings_github"
+        app:title="@string/settings_github"
+        android:summary="github.com/dskja/BetterStreamflix" />
+
+    <Preference
+        app:iconSpaceReserved="false"
+        app:key="p_settings_upstream"
+        app:title="@string/settings_about_upstream"
+        android:summary="github.com/streamflix-reborn2/streamflix" />
+
+    <Preference
+        app:iconSpaceReserved="false"
+        app:key="p_settings_credits"
+        app:title="@string/settings_about_credits"
+        app:summary="@string/settings_about_credits_summary"
+        android:selectable="false" />
 
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/settings_about_tv.xml
+++ b/app/src/main/res/xml/settings_about_tv.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.preference.PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <Preference
@@ -8,5 +9,29 @@
         app:title="@string/settings_about_version"
         tools:summary="@string/settings_about_version_name" />
 
+    <Preference
+        app:iconSpaceReserved="false"
+        app:key="p_settings_about_maintainer"
+        app:title="@string/settings_about_maintainer"
+        android:selectable="false" />
+
+    <Preference
+        app:iconSpaceReserved="false"
+        app:key="p_settings_github"
+        app:title="@string/settings_github"
+        android:summary="github.com/dskja/BetterStreamflix" />
+
+    <Preference
+        app:iconSpaceReserved="false"
+        app:key="p_settings_upstream"
+        app:title="@string/settings_about_upstream"
+        android:summary="github.com/streamflix-reborn2/streamflix" />
+
+    <Preference
+        app:iconSpaceReserved="false"
+        app:key="p_settings_credits"
+        app:title="@string/settings_about_credits"
+        app:summary="@string/settings_about_credits_summary"
+        android:selectable="false" />
 
 </androidx.preference.PreferenceScreen>

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-rootProject.name = "Streamflix"
+rootProject.name = "BetterStreamflix"
 include ':app'
 include ':retrofit-jsoup-converter'
 include ':navigation'


### PR DESCRIPTION
## Summary
- Public rebrand of the mirrored Streamflix codebase to **BetterStreamflix**, maintained by **dskja**
- Updates app name, `applicationId`, deep links (`betterstreamflix://`), in-app updater repo, Telegram (`t.me/BetterStreamflix`), backup folder, About screen, and README
- Credits upstream Streamflix Reborn and the original Streamflix project

## Notes
- Kotlin package/`namespace` stay `com.streamflixreborn.streamflix` to avoid a massive package rename
- Legacy `streamflix://resolve` deep links remain accepted for compatibility

## Test plan
- [ ] App launches as BetterStreamflix on mobile/TV
- [ ] Settings → Help/Telegram open GitHub dskja/BetterStreamflix and t.me/BetterStreamflix
- [ ] About shows maintainer dskja + upstream credit links
- [ ] In-app update targets dskja/BetterStreamflix releases
- [ ] TV bypass QR uses betterstreamflix:// deep links