### PR TITLE
Fix duplicate strings blocking release build

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -71,7 +71,6 @@
     <string name="option_show_unwatched">Marcar como no visto</string>
     <string name="option_clear_program">Quitar de continuar viendo</string>
     <string name="option_clear_recently_watched">Quitar de Vistos recientemente</string>
-    <string name="option_clear_recently_watched">Quitar de Vistos recientemente</string>
     <string name="option_clear_all_recently_watched">Vaciar Vistos recientemente</string>
     <string name="option_cancel">Cancelar</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -63,7 +63,6 @@
     <string name="option_show_unwatched">Segna come non visto</string>
     <string name="option_clear_program">Rimuovi da Continua a Guardare</string>
     <string name="option_clear_recently_watched">Rimuovi da Visti di recente</string>
-    <string name="option_clear_recently_watched">Rimuovi da Visti di recente</string>
     <string name="option_clear_all_recently_watched">Svuota Visti di recente</string>
     <string name="option_cancel">Annulla</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,7 +86,6 @@
     <string name="option_show_unwatched">Mark as unwatched</string>
     <string name="option_clear_program">Remove from Continue Watching</string>
     <string name="option_clear_recently_watched">Remove from Recently Watched</string>
-    <string name="option_clear_recently_watched">Remove from Recently Watched</string>
     <string name="option_clear_all_recently_watched">Clear Recently Watched</string>
     <string name="option_cancel">Cancel</string>
 


### PR DESCRIPTION
Removes duplicated `option_clear_recently_watched` entries in EN/ES/IT strings that broke `assembleRelease`.