### PR TITLE
Provider fixes, configurable URLs, Live TV player, TMDb key hint

### DIFF
--- a/app/src/main/java/com/dskja/betterstreamflix/extractors/FrembedExtractor.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/extractors/FrembedExtractor.kt
@@ -23,8 +23,24 @@ import com.dskja.betterstreamflix.utils.UserPreferences
 class FrembedExtractor (var newUrl: String = "") : Extractor() {
 
     override val name = "Frembed"
-    val defaultUrl = "https://frembed.casa"
+    val defaultUrl = "https://frembed.surf"
     override var mainUrl = newUrl.ifBlank { defaultUrl }
+
+    data class StreamLinkItem(
+        val id: Int? = null,
+        val lang: String? = null,
+        val position: Int? = null,
+        val label: String? = null,
+        val quality: String? = null,
+        val url: String? = null,
+        val host: HostInfo? = null,
+    ) {
+        data class HostInfo(
+            val slug: String? = null,
+            val name: String? = null,
+            val icon: String? = null,
+        )
+    }
 
     data class listLinks (
         val link1: String?=null,
@@ -48,6 +64,10 @@ class FrembedExtractor (var newUrl: String = "") : Extractor() {
         val link5vo: String?=null,
         val link6vo: String?=null,
         val link7vo: String?=null,
+        // Newer frembed.surf series payload also exposes a singular "link" field.
+        val link: String?=null,
+        val link_vostfr: String?=null,
+        val links: List<StreamLinkItem>? = null,
     )
 
     private fun getExtractorName(url: String): String {
@@ -67,26 +87,56 @@ class FrembedExtractor (var newUrl: String = "") : Extractor() {
     }
 
     fun listLinks.toServers(): List<Video.Server> {
-        return listOf(link1, link2, link3, link4, link5, link6, link7,
-                                         link1vostfr, link2vostfr, link3vostfr, link4vostfr, link5vostfr, link6vostfr, link7vostfr,
-                                         link1vo, link2vo, link3vo, link4vo, link5vo, link6vo, link7vo)
+        val fromLinksArray = links.orEmpty().mapIndexedNotNull { index, item ->
+            val data = item.url?.takeIf { it.isNotBlank() } ?: return@mapIndexedNotNull null
+            val lang = when (item.lang?.lowercase()) {
+                "vf", "truefrench", "french" -> "French"
+                "vostfr" -> "VOSTFR"
+                "vo", "en", "vost" -> "VO"
+                else -> item.lang?.uppercase() ?: "French"
+            }
+            val hostName = item.host?.name
+                ?: item.label
+                ?: getExtractorName(if (data.startsWith("/")) mainUrl.removeSuffix("/") + data else data)
+            (if (data.startsWith("/")) mainUrl.removeSuffix("/") + data else data).let {
+                Video.Server(
+                    id = "links$index",
+                    name = "$hostName ($lang)",
+                    src = it,
+                )
+            }
+        }
+        if (fromLinksArray.isNotEmpty()) return fromLinksArray.distinctBy { it.src }
+
+        return listOf(
+            link1, link2, link3, link4, link5, link6, link7,
+            link1vostfr, link2vostfr, link3vostfr, link4vostfr, link5vostfr, link6vostfr, link7vostfr,
+            link1vo, link2vo, link3vo, link4vo, link5vo, link6vo, link7vo,
+            link, link_vostfr,
+        )
             .mapIndexedNotNull { index, data ->
                 if (data.isNullOrEmpty()) return@mapIndexedNotNull null
-                val lang = when { index < 7 -> "French"
-                                  index < 14 -> "VOSTFR"
-                                  else -> "VO" }
+                val lang = when {
+                    index < 7 -> "French"
+                    index < 14 -> "VOSTFR"
+                    index < 21 -> "VO"
+                    index == 21 -> "French"
+                    else -> "VOSTFR"
+                }
                 (if (data.startsWith("/")) mainUrl.removeSuffix("/") + data else data).let {
                     Video.Server(id = "link$index", name = "${getExtractorName(it)} ($lang)", src = it)
                 }
             }
+            .distinctBy { it.src }
     }
 
     private interface Service {
         companion object {
             private const val USER_AGENT =
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
 
             fun build(baseUrl: String): Service {
+                val normalizedBase = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
                 val clientBuilder = OkHttpClient.Builder()
                     .readTimeout(30, TimeUnit.SECONDS)
                     .connectTimeout(30, TimeUnit.SECONDS)
@@ -97,13 +147,17 @@ class FrembedExtractor (var newUrl: String = "") : Extractor() {
                         val url = request.url
                         val referer = "${url.scheme}://${url.host}/"
                         val newRequest = request.newBuilder()
+                            .header("User-Agent", USER_AGENT)
+                            .header("Accept", "application/json,text/plain,*/*")
+                            .header("Accept-Language", "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7")
+                            .header("Origin", referer.trimEnd('/'))
                             .header("Referer", referer)
                             .build()
                         chain.proceed(newRequest)
                     }
 
                 return Retrofit.Builder()
-                    .baseUrl(baseUrl)
+                    .baseUrl(normalizedBase)
                     .addConverterFactory( GsonConverterFactory.create())
                     .client(clientBuilder.dns(DnsResolver.doh).build())
                     .build()

--- a/app/src/main/java/com/dskja/betterstreamflix/extractors/NekostreamExtractor.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/extractors/NekostreamExtractor.kt
@@ -21,78 +21,118 @@ class NekostreamExtractor : Extractor() {
     private val client = OkHttpClient.Builder()
         .dns(DnsResolver.doh)
         .readTimeout(30, TimeUnit.SECONDS)
-        .connectTimeout(30, TimeUnit.SECONDS)
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .callTimeout(45, TimeUnit.SECONDS)
         .build()
 
     override suspend fun extract(link: String): Video {
-        val streamPageUrl = link.substringBefore("?") + link.substringAfter("?", "?autostart=true").let {
-            if (link.contains("?")) "?${link.substringAfter("?")}" else it
-        }
+        val streamPageUrl = normalizeStreamPageUrl(link)
         val pageUri = Uri.parse(streamPageUrl)
         val origin = "${pageUri.scheme}://${pageUri.host}"
         val pageBody = getText(
             url = streamPageUrl,
-            referer = "https://anikototv.to/",
+            referer = when {
+                streamPageUrl.contains("megaplay", ignoreCase = true) -> "https://anikototv.to/"
+                else -> "$origin/"
+            },
             origin = origin,
             accept = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
         )
 
-        val fileId = Regex("""id=["']megaplay-player["'][^>]*data-id=["']([^"']+)""")
-            .find(pageBody)
-            ?.groupValues
-            ?.getOrNull(1)
-            ?: Regex("""data-id=["']([^"']+)["'][^>]*id=["']megaplay-player["']""")
-                .find(pageBody)
-                ?.groupValues
-                ?.getOrNull(1)
+        val fileId = extractPlayerFileId(pageBody)
             ?: throw Exception("Nekostream player file id not found")
 
-        val streamType = Regex("""type:\s*['"]([^'"]+)""")
+        val streamType = Regex("""type:\s*['"]([^'"]+)['"]""")
             .find(pageBody)
             ?.groupValues
             ?.getOrNull(1)
+            ?: Regex("""/stream/[^/]+/\d+/(sub|dub|raw)\b""", RegexOption.IGNORE_CASE)
+                .find(streamPageUrl)
+                ?.groupValues
+                ?.getOrNull(1)
+                ?.lowercase()
 
-        val sourcesUrl = if (pageBody.contains("getSourcesNew")) {
-            "$origin/stream/getSourcesNew?id=$fileId" + (streamType?.let { "&type=$it" } ?: "")
-        } else {
-            "$origin/stream/getSources?id=$fileId"
+        // megaplay.buzz currently serves the playable m3u8 only from getSourcesNew;
+        // legacy getSources returns tracks/enc without a plaintext sources.file.
+        val typeQuery = streamType?.let { "&type=$it" }.orEmpty()
+        val sourcesCandidates = listOf(
+            "$origin/stream/getSourcesNew?id=$fileId$typeQuery",
+            "$origin/stream/getSources?id=$fileId$typeQuery",
+        )
+
+        var lastError: Exception? = null
+        for (sourcesUrl in sourcesCandidates) {
+            try {
+                val sourcesBody = getText(
+                    url = sourcesUrl,
+                    referer = streamPageUrl,
+                    origin = origin,
+                    accept = "application/json, text/javascript, */*; q=0.01",
+                    requestedWith = true,
+                )
+                val sources = Gson().fromJson(sourcesBody, SourcesResponse::class.java)
+                val source = sources.sources?.file
+                    ?: sources.sources?.list?.firstOrNull { !it.file.isNullOrBlank() }?.file
+                    ?: continue
+
+                return Video(
+                    source = source,
+                    subtitles = sources.tracks.orEmpty()
+                        .filter { it.kind == null || it.kind == "captions" }
+                        .mapNotNull {
+                            Video.Subtitle(
+                                label = it.label?.ifBlank { null } ?: "Subtitle",
+                                file = it.file ?: return@mapNotNull null,
+                                default = it.default == true,
+                            )
+                        },
+                    headers = mapOf(
+                        "User-Agent" to USER_AGENT,
+                        "Referer" to "$origin/",
+                        "Origin" to origin,
+                        "Accept" to "*/*",
+                        "Accept-Language" to "en-US,en;q=0.9",
+                        "Connection" to "keep-alive",
+                        "Sec-Fetch-Dest" to "empty",
+                        "Sec-Fetch-Mode" to "cors",
+                        "Sec-Fetch-Site" to "cross-site",
+                        "Sec-GPC" to "1",
+                    ),
+                    type = MimeTypes.APPLICATION_M3U8,
+                )
+            } catch (e: Exception) {
+                lastError = e
+            }
         }
 
-        val sourcesBody = getText(
-            url = sourcesUrl,
-            referer = streamPageUrl,
-            origin = origin,
-            accept = "application/json, text/javascript, */*; q=0.01",
-            requestedWith = true,
-        )
-        val sources = Gson().fromJson(sourcesBody, SourcesResponse::class.java)
-        val source = sources.sources?.file ?: throw Exception("Nekostream source not found")
+        throw lastError ?: Exception("Nekostream source not found")
+    }
 
-        return Video(
-            source = source,
-            subtitles = sources.tracks.orEmpty()
-                .filter { it.kind == null || it.kind == "captions" }
-                .mapNotNull {
-                    Video.Subtitle(
-                        label = it.label?.ifBlank { null } ?: "Subtitle",
-                        file = it.file ?: return@mapNotNull null,
-                        default = it.default == true,
-                    )
-                },
-            headers = mapOf(
-                "User-Agent" to USER_AGENT,
-                "Referer" to "$origin/",
-                "Origin" to origin,
-                "Accept" to "*/*",
-                "Accept-Language" to "en-US,en;q=0.9",
-                "Connection" to "keep-alive",
-                "Sec-Fetch-Dest" to "empty",
-                "Sec-Fetch-Mode" to "cors",
-                "Sec-Fetch-Site" to "cross-site",
-                "Sec-GPC" to "1",
-            ),
-            type = MimeTypes.APPLICATION_M3U8,
-        )
+    private fun normalizeStreamPageUrl(link: String): String {
+        val base = link.substringBefore("?")
+        return if (link.contains("?")) {
+            link
+        } else {
+            "$base?autostart=true"
+        }
+    }
+
+    private fun extractPlayerFileId(pageBody: String): String? {
+        Regex(
+            """id=["']megaplay-player["'][\s\S]*?data-id=["']([^"']+)["']""",
+            RegexOption.IGNORE_CASE,
+        ).find(pageBody)?.groupValues?.getOrNull(1)?.let { return it }
+
+        Regex(
+            """data-id=["']([^"']+)["'][\s\S]*?id=["']megaplay-player["']""",
+            RegexOption.IGNORE_CASE,
+        ).find(pageBody)?.groupValues?.getOrNull(1)?.let { return it }
+
+        // Fallback: first data-id near the player container.
+        return Regex(
+            """class=["'][^"']*form-area[^"']*["'][^>]*data-id=["']([^"']+)["']""",
+            RegexOption.IGNORE_CASE,
+        ).find(pageBody)?.groupValues?.getOrNull(1)
     }
 
     private fun getText(
@@ -131,6 +171,12 @@ class NekostreamExtractor : Extractor() {
     ) {
         data class Sources(
             val file: String? = null,
+            val list: List<SourceItem>? = null,
+        )
+
+        data class SourceItem(
+            val file: String? = null,
+            val type: String? = null,
         )
 
         data class Track(

--- a/app/src/main/java/com/dskja/betterstreamflix/fragments/player/PlayerMobileFragment.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/fragments/player/PlayerMobileFragment.kt
@@ -64,6 +64,7 @@ import com.dskja.betterstreamflix.ui.PlayerMobileView
 import com.dskja.betterstreamflix.utils.MediaServer
 import com.dskja.betterstreamflix.utils.SubtitleOffset
 import com.dskja.betterstreamflix.utils.SubtitleOffsetRenderersFactory
+import com.dskja.betterstreamflix.providers.IptvProvider
 import com.dskja.betterstreamflix.utils.UserPreferences
 import com.dskja.betterstreamflix.utils.UserDataCache
 import com.dskja.betterstreamflix.utils.ProviderAudioLanguage
@@ -597,7 +598,11 @@ class PlayerMobileFragment : Fragment() {
             is Video.Type.Episode -> {
                 nextEpisodeOverlayDismissed = false
                 nextEpisodePrefetchTargetId = null
-                if (EpisodeManager.listIsEmpty(type)) {
+                if (isLiveTvPlayback()) {
+                    EpisodeManager.clearEpisodes()
+                    hideNextEpisodeOverlay()
+                    updatePlayerHeader(type)
+                } else if (EpisodeManager.listIsEmpty(type)) {
                     EpisodeManager.clearEpisodes()
                     lifecycleScope.launch(Dispatchers.IO) {
                         EpisodeManager.addEpisodesFromDb(type, database)
@@ -945,10 +950,18 @@ class PlayerMobileFragment : Fragment() {
             ) + (video.headers ?: emptyMap())
         )
 
+        val mediaItemBuilder = MediaItem.Builder()
+            .setUri(video.source.toUri())
+            .setMimeType(video.type)
+        if (isLiveTvPlayback()) {
+            mediaItemBuilder.setLiveConfiguration(
+                MediaItem.LiveConfiguration.Builder()
+                    .setMaxPlaybackSpeed(1.02f)
+                    .build()
+            )
+        }
         player.setMediaItem(
-            MediaItem.Builder()
-                .setUri(video.source.toUri())
-                .setMimeType(video.type)
+            mediaItemBuilder
                 .setSubtitleConfigurations(
                     subtitleConfigurationsForPlayback(
                         context = requireContext(),
@@ -1271,6 +1284,10 @@ class PlayerMobileFragment : Fragment() {
         is Video.Type.Movie -> type
     }
 
+
+    private fun isLiveTvPlayback(): Boolean =
+        UserPreferences.currentProvider is IptvProvider
+
     private fun resolvePlayerTitle(videoType: Video.Type = currentVideoTypeForUi()): String {
         return when (videoType) {
             is Video.Type.Movie -> videoType.title
@@ -1279,6 +1296,9 @@ class PlayerMobileFragment : Fragment() {
     }
 
     private fun resolvePlayerSubtitle(videoType: Video.Type = currentVideoTypeForUi()): String {
+        if (isLiveTvPlayback()) {
+            return getString(R.string.player_live_badge)
+        }
         return when (videoType) {
             is Video.Type.Movie -> args.subtitle
             is Video.Type.Episode -> {

--- a/app/src/main/java/com/dskja/betterstreamflix/fragments/player/PlayerTvFragment.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/fragments/player/PlayerTvFragment.kt
@@ -81,6 +81,7 @@ import com.dskja.betterstreamflix.utils.NetworkClient
 import com.dskja.betterstreamflix.utils.EpisodeManager
 import com.dskja.betterstreamflix.utils.MediaServer
 import com.dskja.betterstreamflix.utils.PlayerGestureHelper
+import com.dskja.betterstreamflix.providers.IptvProvider
 import com.dskja.betterstreamflix.utils.UserPreferences
 import com.dskja.betterstreamflix.utils.UserDataCache
 import com.dskja.betterstreamflix.utils.ProviderAudioLanguage
@@ -824,7 +825,11 @@ class PlayerTvFragment : Fragment() {
                     nextEpisodeOverlayDismissed = false
                     nextEpisodePrefetchTargetId = null
 
-                    if (EpisodeManager.listIsEmpty(type)) {
+                    if (isLiveTvPlayback()) {
+                        EpisodeManager.clearEpisodes()
+                        hideNextEpisodeOverlay()
+                        updatePlayerHeader(type)
+                    } else if (EpisodeManager.listIsEmpty(type)) {
                         EpisodeManager.clearEpisodes()
                         lifecycleScope.launch(Dispatchers.IO) {
                             EpisodeManager.addEpisodesFromDb(type, database)
@@ -1121,10 +1126,18 @@ class PlayerTvFragment : Fragment() {
                     "User-Agent" to userAgent,
                 ) + (video.headers ?: emptyMap())
             )
+            val mediaItemBuilder = MediaItem.Builder()
+                .setUri(video.source.toUri())
+                .setMimeType(video.type)
+            if (isLiveTvPlayback()) {
+                mediaItemBuilder.setLiveConfiguration(
+                    MediaItem.LiveConfiguration.Builder()
+                        .setMaxPlaybackSpeed(1.02f)
+                        .build()
+                )
+            }
             player.setMediaItem(
-                MediaItem.Builder()
-                    .setUri(video.source.toUri())
-                    .setMimeType(video.type)
+                mediaItemBuilder
                     .setSubtitleConfigurations(
                         subtitleConfigurationsForPlayback(
                             context = requireContext(),
@@ -1508,6 +1521,9 @@ class PlayerTvFragment : Fragment() {
             is Video.Type.Movie -> type
         }
 
+        private fun isLiveTvPlayback(): Boolean =
+            UserPreferences.currentProvider is IptvProvider
+
         private fun resolvePlayerTitle(videoType: Video.Type = currentVideoTypeForUi()): String {
             return when (videoType) {
                 is Video.Type.Movie -> videoType.title
@@ -1516,6 +1532,9 @@ class PlayerTvFragment : Fragment() {
         }
 
         private fun resolvePlayerSubtitle(videoType: Video.Type = currentVideoTypeForUi()): String {
+            if (isLiveTvPlayback()) {
+                return getString(R.string.player_live_badge)
+            }
             return when (videoType) {
                 is Video.Type.Movie -> args.subtitle
                 is Video.Type.Episode -> {

--- a/app/src/main/java/com/dskja/betterstreamflix/fragments/settings/SettingsMobileFragment.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/fragments/settings/SettingsMobileFragment.kt
@@ -924,7 +924,7 @@ class SettingsMobileFragment : PreferenceFragmentCompat() {
         val isPoseidon = UserPreferences.currentProvider?.name == "Poseidonhd2"
         val isAnimeOnlineNinja = UserPreferences.currentProvider is AnimeOnlineNinjaProvider
         val hasConfigProvider = UserPreferences.currentProvider is ProviderConfigUrl
-        val hasSpecificOptions = isStreamingCommunity || isCuevana || isPoseidon || isAnimeOnlineNinja
+        val hasSpecificOptions = isStreamingCommunity || isSerienStream || isMoflix || isCuevana || isPoseidon || isAnimeOnlineNinja
 
         findPreference<PreferenceCategory>("pc_streamingcommunity_settings")?.isVisible = isStreamingCommunity
         findPreference<PreferenceCategory>("pc_serienstream_settings")?.isVisible = isSerienStream

--- a/app/src/main/java/com/dskja/betterstreamflix/fragments/settings/SettingsTvFragment.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/fragments/settings/SettingsTvFragment.kt
@@ -1546,7 +1546,7 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
         val isPoseidon = UserPreferences.currentProvider?.name == "Poseidonhd2"
         val isAnimeOnlineNinja = UserPreferences.currentProvider is AnimeOnlineNinjaProvider
         val hasConfigProvider = UserPreferences.currentProvider is ProviderConfigUrl
-        val hasSpecificOptions = isStreamingCommunity || isCuevana || isPoseidon || isAnimeOnlineNinja
+        val hasSpecificOptions = isStreamingCommunity || isSerienStream || isMoflix || isCuevana || isPoseidon || isAnimeOnlineNinja
 
         findPreference<PreferenceCategory>("pc_streamingcommunity_settings")?.isVisible = isStreamingCommunity
         findPreference<PreferenceCategory>("pc_serienstream_settings")?.isVisible = isSerienStream

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/Altadefinizione01Provider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/Altadefinizione01Provider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Log
 import android.net.Uri
 
@@ -29,10 +34,18 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 import retrofit2.http.Header
 
-object Altadefinizione01Provider : Provider {
+object Altadefinizione01Provider : Provider, ProviderConfigUrl {
 
     override val name: String = "Altadefinizione01"
-    override val baseUrl: String = "https://altadefinizione-01.fun"
+    override val defaultBaseUrl = "https://altadefinizione-01.fun"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        service = Altadefinizione01Service.build(baseUrl.let { if (it.endsWith("/")) it else "$it/" })
+        baseUrl
+    }
     override val logo: String get() = "$baseUrl/templates/altadefinizione01/images/logo.png"
     override val language: String = "it"
 
@@ -116,7 +129,7 @@ object Altadefinizione01Provider : Provider {
         ): okhttp3.ResponseBody
     }
 
-    private val service = Altadefinizione01Service.build(baseUrl)
+    private var service = Altadefinizione01Service.build(defaultBaseUrl)
 
     
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AniWorldProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AniWorldProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.content.Context
 import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
@@ -55,11 +60,18 @@ import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 
-object AniWorldProvider : Provider {
+object AniWorldProvider : Provider, ProviderConfigUrl {
 
 
     private const val URL = "https://aniworld.to/"
-    override val baseUrl = URL
+    override val defaultBaseUrl = "https://aniworld.to/"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
 
     override val name = "AniWorld"
     override val logo = "$URL/public/img/facebook.jpg"

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AnikotoProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AnikotoProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.net.Uri
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -30,9 +35,16 @@ import java.text.Normalizer
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-object AnikotoProvider : Provider {
+object AnikotoProvider : Provider, ProviderConfigUrl {
 
-    override val baseUrl = "https://anikototv.to"
+    override val defaultBaseUrl = "https://anikototv.to"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val name = "Anikoto"
     override val logo = "$baseUrl/AnikotoTheme/assets/images/logo.png"
     override val language = "en"
@@ -274,6 +286,19 @@ object AnikotoProvider : Provider {
                         .joinToString(" - "),
                 )
             }
+        }.ifEmpty {
+            // Fallback when layout drops the .servers wrapper.
+            document.select("li[data-link-id]").mapNotNull {
+                val linkId = it.attr("data-link-id").ifBlank { return@mapNotNull null }
+                Video.Server(
+                    id = "$linkId|$referer",
+                    name = it.text().trim().ifBlank { "Server" },
+                )
+            }
+        }.also { servers ->
+            if (servers.isEmpty()) {
+                throw Exception("Anikoto returned no playable servers for this episode")
+            }
         }
     }
 
@@ -458,13 +483,17 @@ object AnikotoProvider : Provider {
                     .addInterceptor { chain ->
                         val request = chain.request().newBuilder()
                             .header("User-Agent", USER_AGENT)
+                            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
                             .header("Accept-Language", "de,en-US;q=0.9,en;q=0.8")
+                            .header("Referer", "$baseUrl/")
+                            .header("Origin", baseUrl.trimEnd('/'))
                             .header("Cookie", COUNTRY_COOKIE)
                             .build()
                         chain.proceed(request)
                     }
-                    .readTimeout(30, TimeUnit.SECONDS)
-                    .connectTimeout(30, TimeUnit.SECONDS)
+                    .readTimeout(20, TimeUnit.SECONDS)
+                    .connectTimeout(15, TimeUnit.SECONDS)
+                    .callTimeout(35, TimeUnit.SECONDS)
                     .build()
 
                 return Retrofit.Builder()

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeAv1Provider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeAv1Provider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Log
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -24,10 +29,17 @@ import java.util.concurrent.TimeUnit
 import org.json.JSONObject
 import org.json.JSONArray
 
-object AnimeAv1Provider : Provider {
+object AnimeAv1Provider : Provider, ProviderConfigUrl {
 
     override val name = "AnimeAV1"
-    override val baseUrl = "https://animeav1.com"
+    override val defaultBaseUrl = "https://animeav1.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
     override val logo = "https://animeav1.com/favicon.png"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeBumProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeBumProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -19,10 +24,17 @@ import retrofit2.http.Url
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-object AnimeBumProvider : Provider {
+object AnimeBumProvider : Provider, ProviderConfigUrl {
 
     override val name = "AnimeBum"
-    override val baseUrl = "https://www.animebum.net"
+    override val defaultBaseUrl = "https://www.animebum.net"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
     override val logo = "$baseUrl/images/logo.png"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeFlvProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeFlvProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -25,10 +30,17 @@ import retrofit2.http.Query
 import retrofit2.http.Url
 import java.util.concurrent.TimeUnit
 
-object AnimeFlvProvider : Provider {
+object AnimeFlvProvider : Provider, ProviderConfigUrl {
 
     override val name = "AnimeFLV"
-    override val baseUrl = "https://vww.animeflv.one"
+    override val defaultBaseUrl = "https://vww.animeflv.one"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
     override val logo = "$baseUrl/cdn/img/favicon.ico"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -23,6 +23,7 @@ import com.dskja.betterstreamflix.utils.UserPreferences
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withPermit
@@ -37,12 +38,19 @@ import java.net.URLEncoder
 import java.text.Normalizer
 import java.util.concurrent.ConcurrentHashMap
 
-object AnimeOnlineNinjaProvider : Provider {
+object AnimeOnlineNinjaProvider : Provider, ProviderConfigUrl {
 
     private const val SITE_BASE_URL = "https://ww3.animeonline.ninja"
 
     override val name = "Anime Online Ninja"
-    override val baseUrl = SITE_BASE_URL
+    override val defaultBaseUrl = "https://ww3.animeonline.ninja"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo: String
         get() = artworkUrl("$baseUrl/wp-content/uploads/2019/09/cropped-avatar2-1-300x300.jpg")
             ?: "$baseUrl/wp-content/uploads/2019/09/cropped-avatar2-1-300x300.jpg"
@@ -269,7 +277,11 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     override suspend fun getHome(): List<Category> {
-        val document = getDocument("$baseUrl/inicio/")
+        val document = try {
+            getDocument("$baseUrl/inicio/")
+        } catch (e: Exception) {
+            throw Exception("Anime Online Ninja home failed (${e.message}). Cloudflare clearance may be required.")
+        }
         val categories = parseHomeCategories(document).takeIf { it.isNotEmpty() }
             ?: throw IllegalStateException("AnimeOnline Ninja home page contained no recognizable categories")
         return resolveHomeEpisodeCards(categories)
@@ -283,13 +295,15 @@ object AnimeOnlineNinjaProvider : Provider {
 
         if (episodeCards.isEmpty()) return@coroutineScope categories
 
-        val requestLimit = Semaphore(4)
+        val requestLimit = Semaphore(3)
         val resolvedByTitle = episodeCards
             .distinctBy { titleKey(it.title) }
             .map { episodeCard ->
                 async {
                     val tvShowResult = runCatching {
-                        requestLimit.withPermit { getTvShow(episodeCard.id) }
+                        kotlinx.coroutines.withTimeout(12_000L) {
+                            requestLimit.withPermit { getTvShow(episodeCard.id) }
+                        }
                     }
                     val movieResult = if (tvShowResult.isFailure) {
                         runCatching {

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeSaturnProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeSaturnProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.models.Category
 import com.dskja.betterstreamflix.models.Episode
@@ -34,9 +39,17 @@ import org.json.JSONObject
 import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 
-object AnimeSaturnProvider : Provider {
+object AnimeSaturnProvider : Provider, ProviderConfigUrl {
     override val name = "AnimeSaturn"
-    override val baseUrl = "https://www.animesaturn.net"
+    override val defaultBaseUrl = "https://www.animesaturn.net"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        service = AnimeSaturnService.build(baseUrl.let { if (it.endsWith("/")) it else "$it/" })
+        baseUrl
+    }
 
     override val logo = "https://www.animesaturn.net/assets/img/saturn.png"
     override val language = "it"
@@ -114,7 +127,7 @@ object AnimeSaturnProvider : Provider {
         suspend fun getEpisodes(@Body body: okhttp3.RequestBody): okhttp3.ResponseBody
     }
 
-    private val service = AnimeSaturnService.build(baseUrl)
+    private var service = AnimeSaturnService.build(defaultBaseUrl)
 
     private val kitsuService by lazy {
         val client = OkHttpClient.Builder()

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeUnityProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeUnityProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.models.Category
 import com.dskja.betterstreamflix.models.Episode
@@ -33,9 +38,17 @@ import org.json.JSONObject
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import java.util.concurrent.TimeUnit
 
-object AnimeUnityProvider : Provider {
+object AnimeUnityProvider : Provider, ProviderConfigUrl {
     override val name = "AnimeUnity"
-    override val baseUrl = "https://www.animeunity.so"
+    override val defaultBaseUrl = "https://www.animeunity.so"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        service = AnimeUnityService.build(baseUrl.let { if (it.endsWith("/")) it else "$it/" })
+        baseUrl
+    }
     override val logo: String get() = "$baseUrl/images/scritta2.png"
     override val language = "it"
     
@@ -222,7 +235,7 @@ object AnimeUnityProvider : Provider {
         }
     }
 
-    private val service = AnimeUnityService.build(baseUrl)
+    private var service = AnimeUnityService.build(defaultBaseUrl)
 
 
     override suspend fun getHome(): List<Category> {

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeWorldProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeWorldProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import MyCookieJar
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -31,10 +36,17 @@ import java.net.URLDecoder
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 
-object AnimeWorldProvider : Provider {
+object AnimeWorldProvider : Provider, ProviderConfigUrl {
 
     private const val URL = "https://www.animeworld.ac"
-    override val baseUrl = URL
+    override val defaultBaseUrl = "https://www.animeworld.ac"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     private const val USER_AGENT = "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
 
     override val name = "AnimeWorld"

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AnimefenixProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AnimefenixProvider.kt
@@ -1,153 +1,223 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
 import com.dskja.betterstreamflix.models.*
 import com.dskja.betterstreamflix.utils.DnsResolver
+import com.dskja.betterstreamflix.utils.NetworkClient
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import okhttp3.Cache
 import okhttp3.OkHttpClient
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import retrofit2.Retrofit
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Url
-import java.io.File
 import java.util.concurrent.TimeUnit
 import android.util.Log
 
-object AnimefenixProvider : Provider {
+object AnimefenixProvider : Provider, ProviderConfigUrl {
 
     override val name = "Animefenix"
-    override val baseUrl = "https://animefenix2.tv"
+    // animefenix2.tv is dead from many networks; animefenix.live is the current working mirror.
+    override val defaultBaseUrl = "https://animefenix.live"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
-    override val logo = "https://animefenix2.tv/themes/fenix-neo/images/AveFenix.png"
+    override val logo = "$defaultBaseUrl/images/animefenix-logo.png"
 
-    private val client = getOkHttpClient()
+    private const val TAG = "AnimefenixProvider"
 
-    private val service = Retrofit.Builder()
-        .baseUrl(baseUrl)
-        .addConverterFactory(JsoupConverterFactory.create())
-        .client(client)
-        .build()
-        .create(AnimefenixService::class.java)
+    private val service by lazy {
+        Retrofit.Builder()
+            .baseUrl(if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/")
+            .addConverterFactory(JsoupConverterFactory.create())
+            .client(buildClient())
+            .build()
+            .create(AnimefenixService::class.java)
+    }
 
-    private fun getOkHttpClient(): OkHttpClient {
-        return OkHttpClient.Builder()
-            .cache(Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024))
-            .readTimeout(30, TimeUnit.SECONDS)
-            .connectTimeout(30, TimeUnit.SECONDS)
+    private fun buildClient(): OkHttpClient {
+        return NetworkClient.default.newBuilder()
+            .readTimeout(20, TimeUnit.SECONDS)
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .callTimeout(35, TimeUnit.SECONDS)
             .dns(DnsResolver.doh)
+            .addInterceptor { chain ->
+                val original = chain.request()
+                val request = original.newBuilder()
+                    .header(
+                        "User-Agent",
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                    )
+                    .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                    .header("Accept-Language", "es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7")
+                    .header("Referer", "${baseUrl.trimEnd('/')}/")
+                    .header("Origin", baseUrl.trimEnd('/'))
+                    .build()
+                chain.proceed(request)
+            }
             .build()
     }
 
     private interface AnimefenixService {
         @GET
-        suspend fun getPage(@Url url: String): Document
+        suspend fun getPage(
+            @Url url: String,
+            @Header("Referer") referer: String = "",
+        ): Document
     }
 
-    private fun parseShows(elements: List<Element>): List<TvShow> {
-        return elements.mapNotNull {
-            val a = it.selectFirst("a") ?: it
-            val titleElement = it.selectFirst("h3, p:not(.gray)")
-            val imageElement = it.selectFirst("img")
+    private fun absoluteUrl(href: String): String {
+        return when {
+            href.startsWith("http") -> href
+            href.startsWith("/") -> "${baseUrl.trimEnd('/')}$href"
+            else -> "${baseUrl.trimEnd('/')}/$href"
+        }
+    }
 
+    private fun parseAnimeCards(elements: List<Element>): List<TvShow> {
+        return elements.mapNotNull { el ->
+            val a = when {
+                el.tagName().equals("a", ignoreCase = true) &&
+                    el.attr("href").contains("/anime/") -> el
+                else -> el.selectFirst("a[href*=/anime/]")
+                    ?: el.selectFirst("a[href]")
+                    ?: return@mapNotNull null
+            }
+            val href = a.attr("href").ifBlank { return@mapNotNull null }
+            val title = el.selectFirst("h3, .title, .anime-title, .media-body h3, .description h3, p:not(.gray)")
+                ?.text()
+                ?.trim()
+                ?.ifBlank { null }
+                ?: a.attr("title").ifBlank { a.text() }.trim()
+            if (title.isBlank()) return@mapNotNull null
+            val image = el.selectFirst("img")
             TvShow(
-                id = a.attr("href"),
-                title = titleElement?.text() ?: "",
-                poster = imageElement?.let { img ->
-                    img.attr("data-src").ifEmpty { img.attr("src") }
-                }
+                id = absoluteUrl(href),
+                title = title,
+                poster = image?.attr("data-src")?.ifBlank { null }
+                    ?: image?.attr("src")?.ifBlank { null }
             )
-        }
+        }.distinctBy { it.id }
     }
 
-    private fun parseMovies(elements: List<Element>): List<Movie> {
-        return elements.mapNotNull {
-            val a = it.selectFirst("a") ?: return@mapNotNull null
-            val posterElement = it.selectFirst(".main-img img")
-            Movie(
-                id = a.attr("href"),
-                title = it.selectFirst("p:not(.gray)")?.text() ?: "",
-                poster = posterElement?.attr("data-src")?.ifEmpty { posterElement.attr("src") }
+    private fun parseHomeEpisodes(document: Document): List<TvShow> {
+        return document.select("a[href*=/ver/]").mapNotNull { a ->
+            val href = a.attr("href").ifBlank { return@mapNotNull null }
+            val title = a.selectFirst(".title, .anime-title, h3, h4")?.text()?.trim()
+                ?: a.attr("title").ifBlank { a.text() }.trim()
+            if (title.isBlank()) return@mapNotNull null
+            val image = a.selectFirst("img")
+            TvShow(
+                id = absoluteUrl(href),
+                title = title,
+                poster = image?.attr("data-src")?.ifBlank { null }
+                    ?: image?.attr("src")?.ifBlank { null }
             )
-        }
+        }.distinctBy { it.id }
     }
 
     override suspend fun getHome(): List<Category> {
         return try {
             coroutineScope {
-                val premieres2025Deferred = async { service.getPage("$baseUrl/directorio/anime?estreno=2025") }
-                val premieres2024Deferred = async { service.getPage("$baseUrl/directorio/anime?estreno=2024") }
-                val premieres2023Deferred = async { service.getPage("$baseUrl/directorio/anime?estreno=2023") }
+                val homeDeferred = async { service.getPage(baseUrl) }
+                val directoryDeferred = async { service.getPage("$baseUrl/directorio") }
 
                 val categories = mutableListOf<Category>()
+                var sawCloudflare = false
 
-                try {
-                    val premieres2025Document = premieres2025Deferred.await()
-                    val bannerShows = parseShows(premieres2025Document.select(".grid-animes li article")).map {
-                        it.copy(banner = it.poster)
+                runCatching {
+                    val home = homeDeferred.await()
+                    if (looksLikeCloudflare(home)) {
+                        sawCloudflare = true
+                        return@runCatching
                     }
-                    if (bannerShows.isNotEmpty()) {
-                        categories.add(Category(Category.FEATURED, bannerShows.take(10)))
+                    val latest = parseHomeEpisodes(home).take(24)
+                    if (latest.isNotEmpty()) {
+                        categories.add(Category("Últimos episodios", latest))
                     }
-                } catch (e: Exception) { /* No-op */ }
+                    val featured = parseAnimeCards(home.select(".anime, .animes .anime, .media.anime")).take(20)
+                    if (featured.isNotEmpty()) {
+                        categories.add(Category(Category.FEATURED, featured.map { it.copy(banner = it.poster) }))
+                    }
+                }.onFailure { Log.w(TAG, "Home parse failed: ${it.message}") }
 
-                try {
-                    val premieres2024Document = premieres2024Deferred.await()
-                    val premieres2024Shows = parseShows(premieres2024Document.select(".grid-animes li article"))
-                    if (premieres2024Shows.isNotEmpty()) {
-                        categories.add(Category("Estrenos 2024", premieres2024Shows))
+                runCatching {
+                    val directory = directoryDeferred.await()
+                    if (looksLikeCloudflare(directory)) {
+                        sawCloudflare = true
+                        return@runCatching
                     }
-                } catch (e: Exception) { /* No-op */ }
-
-                try {
-                    val premieres2023Document = premieres2023Deferred.await()
-                    val premieres2023Shows = parseShows(premieres2023Document.select(".grid-animes li article"))
-                    if (premieres2023Shows.isNotEmpty()) {
-                        categories.add(Category("Estrenos 2023", premieres2023Shows))
+                    val shows = parseAnimeCards(
+                        directory.select(
+                            ".anime, .animes .anime, .media.anime, li.anime, " +
+                                "article, .group, .card, a[href*=/anime/]"
+                        )
+                    )
+                    if (shows.isNotEmpty()) {
+                        categories.add(Category("Directorio", shows))
                     }
-                } catch (e: Exception) { /* No-op */ }
+                }.onFailure { Log.w(TAG, "Directory parse failed: ${it.message}") }
 
-                return@coroutineScope categories
+                if (categories.isEmpty() && sawCloudflare) {
+                    throw Exception(
+                        "Animefenix bloqueado por Cloudflare en $baseUrl. " +
+                            "Abre el sitio en el dispositivo o cambia la URL del proveedor."
+                    )
+                }
+                if (categories.isEmpty()) {
+                    throw Exception("Animefenix home vacío en $baseUrl (dominio o selectores desactualizados)")
+                }
+                categories
             }
         } catch (e: Exception) {
-            emptyList()
+            Log.e(TAG, "getHome failed: ${e.message}", e)
+            throw e
         }
+    }
+
+    private fun looksLikeCloudflare(document: Document): Boolean {
+        val html = document.html()
+        return html.contains("Just a moment", ignoreCase = true) ||
+            html.contains("cf-browser-verification", ignoreCase = true) ||
+            html.contains("Checking your browser", ignoreCase = true) ||
+            html.contains("challenge-platform", ignoreCase = true)
     }
 
     override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
         if (query.isBlank()) {
             return listOf(
-                Genre("1", "Acción"), Genre("23", "Aventuras"), Genre("20", "Ciencia Ficción"),
-                Genre("5", "Comedia"), Genre("8", "Deportes"), Genre("38", "Demonios"),
-                Genre("6", "Drama"), Genre("11", "Ecchi"), Genre("2", "Escolares"),
-                Genre("13", "Fantasía"), Genre("28", "Harem"), Genre("24", "Historico"),
-                Genre("47", "Horror"), Genre("25", "Infantil"), Genre("51", "Isekai"),
-                Genre("29", "Josei"), Genre("14", "Magia"), Genre("26", "Artes Marciales"),
-                Genre("21", "Mecha"), Genre("22", "Militar"), Genre("17", "Misterio"),
-                Genre("36", "Música"), Genre("30", "Parodia"), Genre("31", "Policía"),
-                Genre("18", "Psicológico"), Genre("10", "Recuentos de la vida"), Genre("3", "Romance"),
-                Genre("34", "Samurai"), Genre("7", "Seinen"), Genre("4", "Shoujo"),
-                Genre("9", "Shounen"), Genre("12", "Sobrenatural"), Genre("15", "Superpoderes"),
-                Genre("19", "Suspenso"), Genre("27", "Terror"), Genre("39", "Vampiros"),
-                Genre("40", "Yaoi"), Genre("37", "Yuri")
+                Genre("accion", "Acción"), Genre("aventura", "Aventura"), Genre("comedia", "Comedia"),
+                Genre("drama", "Drama"), Genre("fantasia", "Fantasía"), Genre("romance", "Romance"),
+                Genre("shounen", "Shounen"), Genre("seinen", "Seinen"), Genre("sobrenatural", "Sobrenatural")
             )
         }
         return try {
-            val document = service.getPage("$baseUrl/directorio/anime?q=$query&p=$page")
-            parseShows(document.select(".grid-animes li article")).distinctBy { it.id }
+            val document = service.getPage("$baseUrl/directorio?q=${java.net.URLEncoder.encode(query, "UTF-8")}&p=$page")
+            parseAnimeCards(document.select(".anime, .animes .anime, .media.anime, li.anime"))
         } catch (e: Exception) {
+            Log.w(TAG, "search failed: ${e.message}")
             emptyList()
         }
     }
 
     override suspend fun getTvShows(page: Int): List<TvShow> {
         return try {
-            val document = service.getPage("$baseUrl/directorio/anime?p=$page")
-            parseShows(document.select(".grid-animes li article"))
+            val document = service.getPage("$baseUrl/directorio?p=$page")
+            parseAnimeCards(document.select(".anime, .animes .anime, .media.anime, li.anime"))
         } catch (e: Exception) {
             emptyList()
         }
@@ -155,8 +225,10 @@ object AnimefenixProvider : Provider {
 
     override suspend fun getMovies(page: Int): List<Movie> {
         return try {
-            val document = service.getPage("$baseUrl/directorio/anime?tipo=2&p=$page")
-            parseMovies(document.select(".grid-animes li article"))
+            val document = service.getPage("$baseUrl/directorio?tipo=2&p=$page")
+            parseAnimeCards(document.select(".anime, .animes .anime, .media.anime, li.anime")).map {
+                Movie(id = it.id, title = it.title, poster = it.poster)
+            }
         } catch (e: Exception) {
             emptyList()
         }
@@ -164,114 +236,116 @@ object AnimefenixProvider : Provider {
 
     override suspend fun getGenre(id: String, page: Int): Genre {
         return try {
-            val document = service.getPage("$baseUrl/directorio/anime?genero=$id&p=$page")
-            val shows = parseShows(document.select(".grid-animes li article"))
-            val genreName = document.selectFirst("h1.text-4xl")?.ownText()?.trim() ?: "Género"
-            Genre(id = id, name = genreName, shows = shows)
+            val document = service.getPage("$baseUrl/directorio?genero=$id&p=$page")
+            val shows = parseAnimeCards(document.select(".anime, .animes .anime, .media.anime, li.anime"))
+            Genre(id = id, name = id.replaceFirstChar { it.uppercase() }, shows = shows)
         } catch (e: Exception) {
             Genre(id = id, name = "Error", shows = emptyList())
         }
     }
 
     override suspend fun getMovie(id: String): Movie {
-        return try {
-            val document = service.getPage(id)
-            val title = document.selectFirst("h1.text-4xl")?.ownText() ?: ""
-            val poster = document.selectFirst("#anime_image")?.let {
-                it.attr("data-src").ifEmpty { it.attr("src") }
-            }
-            val overview = document.selectFirst(".mb-6 p.text-gray-300")?.text()
-            val genres = document.select("a.bg-gray-800").map {
-                Genre(
-                    id = it.attr("href").substringAfterLast("/"),
-                    name = it.text()
-                )
-            }
-            Movie(id = id, title = title, poster = poster, overview = overview, genres = genres)
-        } catch (e: Exception) {
-            Movie(id = id, title = "Error al cargar")
-        }
+        val show = getTvShow(id)
+        return Movie(
+            id = show.id,
+            title = show.title,
+            overview = show.overview,
+            poster = show.poster,
+            banner = show.banner,
+            genres = show.genres,
+        )
     }
 
     override suspend fun getTvShow(id: String): TvShow {
         return try {
-            val document = service.getPage(id)
-            val title = document.selectFirst("h1.text-4xl")?.ownText() ?: ""
-            val poster = document.selectFirst("#anime_image")?.let {
+            val url = absoluteUrl(id)
+            val document = service.getPage(url)
+            val title = document.selectFirst("h1.anime-title, h1.text-4xl, h1")?.ownText()?.trim()
+                ?: document.selectFirst("h1")?.text()?.trim()
+                ?: ""
+            val poster = document.selectFirst("#anime_image, .thumb img, .anime-single img")?.let {
                 it.attr("data-src").ifEmpty { it.attr("src") }
             }
+            val overview = document.selectFirst("h2:contains(Sinopsis) + p, .mb-6 p.text-gray-300, .sinopsis p, .description")
+                ?.text()
+            val genres = document.select("a[href*=genero], a[href*=/directorio]").mapNotNull {
+                val name = it.text().trim()
+                if (name.isBlank() || name.equals("Animes", true)) return@mapNotNull null
+                Genre(id = it.attr("href").substringAfter("genero=").substringAfterLast("/"), name = name)
+            }.distinctBy { it.name }
 
-            // 1. Mejora en la sinopsis para el nuevo tema Neo
-            val overview = document.selectFirst("h2:contains(Sinopsis) + p")?.text()
-                ?: document.selectFirst(".mb-6 p.text-gray-300")?.text()
-
-            // 2. Mejora en los géneros
-            val genres = document.select("a[href*=/directorio/anime?genero=]").map {
-                Genre(id = it.attr("href").substringAfterLast("/"), name = it.text().trim())
-            }
-
-            // 3. Extracción de episodios AJAX usando la técnica de Corrutinas
             val episodes = mutableListOf<Episode>()
-            val slug = id.substringAfterLast("/")
+            val slug = url.trimEnd('/').substringAfterLast("/")
 
-            // Buscamos los botones de las páginas (Ej: "1 - 50", "51 - 100")
-            val episodeButtons = document.select(".episode-navigation button.episode-btn")
-            val startValues = if (episodeButtons.isNotEmpty()) {
-                episodeButtons.mapNotNull { btn ->
-                    Regex("""loadEpisodes\((\d+)""").find(btn.attr("onclick"))?.groupValues?.get(1)
-                }.distinct()
-            } else {
-                listOf("0") // Valor por defecto si solo hay una página
+            // Current mirror embeds episode numbers in page JS: var episodes = [8,7,6,...]
+            val scriptEpisodes = document.select("script").mapNotNull { script ->
+                Regex("""var\s+episodes\s*=\s*\[([^\]]+)\]""")
+                    .find(script.data())
+                    ?.groupValues
+                    ?.getOrNull(1)
+            }.firstOrNull()
+            if (!scriptEpisodes.isNullOrBlank()) {
+                scriptEpisodes.split(',')
+                    .mapNotNull { it.trim().toIntOrNull() }
+                    .sorted()
+                    .forEach { number ->
+                        episodes += Episode(
+                            id = absoluteUrl("/ver/$slug-$number"),
+                            number = number,
+                            title = "Episodio $number",
+                        )
+                    }
             }
 
-            // Descargamos las páginas en paralelo
-            coroutineScope {
-                val deferredEpisodes = startValues.map { start ->
-                    async {
-                        try {
-                            // Imita la llamada AJAX de la página web
-                            val ajaxUrl = "$id?id=$slug&load=episodes&start=$start"
-                            val epDoc = service.getPage(ajaxUrl)
-
-                            epDoc.select(".episode-card").mapNotNull { epEl ->
-                                val rawHref = epEl.attr("href")
-                                if (rawHref.isNullOrBlank()) return@mapNotNull null
-                                val epUrl = if (rawHref.startsWith("http")) rawHref else "$baseUrl$rawHref"
-
-                                val epTitle = epEl.selectFirst(".ep-title")?.text()?.trim() ?: "Episodio"
-                                val epImg = epEl.selectFirst("img")?.let { img ->
-                                    img.attr("data-src").ifEmpty { img.attr("src") }
-                                } ?: ""
-                                val epNum = Regex("""\d+""").find(epTitle)?.value?.toIntOrNull() ?: 0
-
-                                Episode(
-                                    id = epUrl,
-                                    number = epNum,
-                                    title = epTitle,
-                                    poster = epImg
-                                )
-                            }
-                        } catch (e: Exception) {
-                            emptyList<Episode>()
-                        }
-                    }
+            // Legacy Neo theme AJAX episode cards
+            if (episodes.isEmpty()) {
+                val episodeButtons = document.select(".episode-navigation button.episode-btn")
+                val startValues = if (episodeButtons.isNotEmpty()) {
+                    episodeButtons.mapNotNull { btn ->
+                        Regex("""loadEpisodes\((\d+)""").find(btn.attr("onclick"))?.groupValues?.get(1)
+                    }.distinct()
+                } else {
+                    listOf("0")
                 }
 
-                deferredEpisodes.map { it.await() }.forEach { episodes.addAll(it) }
+                coroutineScope {
+                    val deferredEpisodes = startValues.map { start ->
+                        async {
+                            try {
+                                val ajaxUrl = "$url?id=$slug&load=episodes&start=$start"
+                                val epDoc = service.getPage(ajaxUrl)
+                                epDoc.select(".episode-card, .episodes-list a[href*=/ver/], a[href*=/ver/]").mapNotNull { epEl ->
+                                    val rawHref = epEl.attr("href")
+                                    if (rawHref.isBlank()) return@mapNotNull null
+                                    val epUrl = absoluteUrl(rawHref)
+                                    val epTitle = epEl.selectFirst(".ep-title, .d-title, b")?.text()?.trim()
+                                        ?: epEl.text().trim().ifBlank { "Episodio" }
+                                    val epNum = Regex("""\d+""").find(epTitle)?.value?.toIntOrNull()
+                                        ?: Regex("""-(\d+)$""").find(epUrl)?.groupValues?.getOrNull(1)?.toIntOrNull()
+                                        ?: 0
+                                    Episode(id = epUrl, number = epNum, title = epTitle)
+                                }
+                            } catch (_: Exception) {
+                                emptyList()
+                            }
+                        }
+                    }
+                    deferredEpisodes.map { it.await() }.forEach { episodes.addAll(it) }
+                }
             }
 
-            // Aseguramos el orden correcto (menor a mayor)
             episodes.sortBy { it.number }
 
             TvShow(
-                id = id,
+                id = url,
                 title = title,
                 poster = poster,
                 overview = overview,
                 genres = genres,
-                seasons = listOf(Season(id = id, number = 1, title = "Episodios", episodes = episodes))
+                seasons = listOf(Season(id = url, number = 1, title = "Episodios", episodes = episodes))
             )
         } catch (e: Exception) {
+            Log.e(TAG, "getTvShow failed: ${e.message}", e)
             TvShow(id = id, title = "Error al cargar")
         }
     }
@@ -279,7 +353,7 @@ object AnimefenixProvider : Provider {
     override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
         return try {
             getTvShow(seasonId).seasons.firstOrNull()?.episodes ?: emptyList()
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             emptyList()
         }
     }
@@ -287,39 +361,75 @@ object AnimefenixProvider : Provider {
     override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
         return try {
             val url = if (videoType is Video.Type.Movie) {
-                val moviePage = service.getPage(id)
-                moviePage.selectFirst(".divide-y li > a")?.attr("href") ?: id
+                val moviePage = service.getPage(absoluteUrl(id))
+                moviePage.selectFirst(".divide-y li > a, .episodes-list a[href*=/ver/], a[href*=/ver/]")
+                    ?.attr("href")
+                    ?.let(::absoluteUrl)
+                    ?: absoluteUrl(id)
             } else {
-                id
+                absoluteUrl(id)
             }
 
             val document = service.getPage(url)
-            val script = document.selectFirst("script:containsData(var tabsArray)") ?: return emptyList()
+            val servers = mutableListOf<Video.Server>()
 
-            val names = document.select(".episode-page__servers-list li a").map { a ->
-                a.select("span").last()?.text()?.trim().orEmpty()
+            // Legacy tabsArray iframe embeds
+            document.selectFirst("script:containsData(var tabsArray)")?.let { script ->
+                val names = document.select(".episode-page__servers-list li a, .servers li a, .nav-tabs a").map { a ->
+                    a.select("span").last()?.text()?.trim().orEmpty().ifBlank { a.text().trim() }
+                }
+                val urls = script.data()
+                    .substringAfter("<iframe").split("src='")
+                    .drop(1)
+                    .map { it.substringBefore("'").substringAfter("redirect.php?id=").trim() }
+                val count = minOf(urls.size, names.size.coerceAtLeast(urls.size))
+                for (i in 0 until count) {
+                    val src = urls.getOrNull(i)?.takeIf { it.isNotBlank() } ?: continue
+                    val name = names.getOrNull(i)?.ifBlank { null } ?: "Server ${i + 1}"
+                    servers += Video.Server(id = src, name = name, src = src)
+                }
             }
 
-            val urls = script.data()
-                .substringAfter("<iframe").split("src='")
-                .drop(1)
-                .map { it.substringBefore("'").substringAfter("redirect.php?id=").trim() }
-
-            val count = minOf(urls.size, names.size)
-            val servers = (0 until count).mapNotNull { i ->
-                val name = names[i].ifBlank { return@mapNotNull null }
-                val urlValue = urls[i]
-                Video.Server(id = urlValue, name = name)
+            // Direct iframes / data-src embeds on current mirror
+            if (servers.isEmpty()) {
+                document.select("iframe[src], iframe[data-src], [data-url]").forEachIndexed { index, el ->
+                    val src = el.attr("src").ifBlank { el.attr("data-src") }.ifBlank { el.attr("data-url") }
+                    if (src.isBlank() || src.startsWith("about:")) return@forEachIndexed
+                    val absolute = when {
+                        src.startsWith("//") -> "https:$src"
+                        src.startsWith("http") -> src
+                        src.contains("redirect.php?id=") -> absoluteUrl(src.substringAfter("redirect.php?id=").let { "/redirect.php?id=$it" })
+                        else -> absoluteUrl(src)
+                    }
+                    servers += Video.Server(
+                        id = absolute,
+                        name = "Server ${index + 1}",
+                        src = absolute,
+                    )
+                }
             }
 
-            servers
+            // redirect.php links in page scripts
+            if (servers.isEmpty()) {
+                Regex("""redirect\.php\?id=([^"'\s]+)""")
+                    .findAll(document.html())
+                    .map { it.groupValues[1] }
+                    .distinct()
+                    .forEachIndexed { index, encoded ->
+                        val src = if (encoded.startsWith("http")) encoded else absoluteUrl("/redirect.php?id=$encoded")
+                        servers += Video.Server(id = src, name = "Server ${index + 1}", src = src)
+                    }
+            }
+
+            servers.distinctBy { it.src.ifBlank { it.id } }
         } catch (e: Exception) {
+            Log.w(TAG, "getServers failed: ${e.message}")
             emptyList()
         }
     }
 
     override suspend fun getVideo(server: Video.Server): Video {
-        return Extractor.extract(server.id, server)
+        return Extractor.extract(server.src.ifBlank { server.id }, server)
     }
 
     override suspend fun getPeople(id: String, page: Int): People {

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AnyMovieProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AnyMovieProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -28,10 +33,17 @@ import retrofit2.http.Query
 import retrofit2.http.Url
 import java.util.concurrent.TimeUnit
 
-object AnyMovieProvider : Provider {
+object AnyMovieProvider : Provider, ProviderConfigUrl {
 
     private const val URL = "https://anymovie.cc/"
-    override val baseUrl = URL
+    override val defaultBaseUrl = "https://anymovie.cc/"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val name = "AnyMovie"
     override val logo = "$URL/wp-content/uploads/2023/08/AM-LOGO-1.png"
     override val language = "en"

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/CB01Provider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/CB01Provider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.models.Category
@@ -32,10 +37,18 @@ import okhttp3.ResponseBody
 import java.util.concurrent.TimeUnit
 import org.json.JSONObject
 
-object CB01Provider : Provider {
+object CB01Provider : Provider, ProviderConfigUrl {
 
     override val name = "CB01"
-    override val baseUrl = "https://cb01official.uno"
+    override val defaultBaseUrl = "https://cb01official.uno"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        service = CB01Service.build(baseUrl.let { if (it.endsWith("/")) it else "$it/" })
+        baseUrl
+    }
     override val logo: String get() = "$baseUrl/apple-icon-180x180px.png"
     override val language = "it"
 
@@ -96,7 +109,7 @@ object CB01Provider : Provider {
         }
     }
 
-    private val service = CB01Service.build(baseUrl)
+    private var service = CB01Service.build(defaultBaseUrl)
 
     private interface StayService {
         @FormUrlEncoded

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/CableVisionHDProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/CableVisionHDProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.models.*
@@ -18,9 +23,16 @@ import java.net.ServerSocket
 import java.net.Socket
 import java.net.URLDecoder
 
-object CableVisionHDProvider : IptvProvider {
+object CableVisionHDProvider : IptvProvider, ProviderConfigUrl {
     override val name = "CableVisionHD"
-    override val baseUrl = "https://www.cablevisionhd.com"
+    override val defaultBaseUrl = "https://www.cablevisionhd.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/4gMQkN2b/imagen-2025-09-05-212536248.png"
     override val language = "es"
 
@@ -402,21 +414,31 @@ object CableVisionHDProvider : IptvProvider {
             val doc = fetchDocument(id) ?: throw Exception("No se pudo cargar")
             val servers = mutableListOf<Video.Server>()
 
-            doc.select("div.options-left a.option").forEach { element ->
-                val name = element.text().trim()
-                val url = element.attr("href")
-
+            doc.select(
+                "div.options-left a.option, .options a.option, a.option, .server-list a, " +
+                    "ul.Options li a, .player-options a, a[href*=player], iframe[src], iframe[data-src]"
+            ).forEach { element ->
+                val name = element.text().trim().ifBlank {
+                    element.attr("title").ifBlank { "Opción" }
+                }
+                val url = element.attr("href").ifBlank {
+                    element.attr("data-src").ifBlank { element.attr("src") }
+                }
                 if (url.isNotEmpty()) {
-                    val absoluteUrl = if (url.startsWith("http")) url else "$baseUrl/$url"
-                    servers.add(Video.Server(id = absoluteUrl, name = name))
+                    val absoluteUrl = when {
+                        url.startsWith("http") -> url
+                        url.startsWith("//") -> "https:$url"
+                        else -> "$baseUrl/${url.trimStart('/')}"
+                    }
+                    servers.add(Video.Server(id = absoluteUrl, name = name, src = absoluteUrl))
                 }
             }
 
             servers.distinctBy { it.id }.ifEmpty {
-                listOf(Video.Server(id = id, name = "Opción 1"))
+                listOf(Video.Server(id = id, name = "Opción 1", src = id))
             }
         } catch (e: Exception) {
-            listOf(Video.Server(id = id, name = "Opción 1"))
+            listOf(Video.Server(id = id, name = "Opción 1", src = id))
         }
     }
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/Cine24hProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/Cine24hProvider.kt
@@ -1,5 +1,7 @@
 package com.dskja.betterstreamflix.providers
 
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.content.Context
 import android.util.Base64
 import android.util.Log
@@ -20,10 +22,17 @@ import org.jsoup.nodes.Document
 import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 
-object Cine24hProvider : Provider {
+object Cine24hProvider : Provider, ProviderConfigUrl {
 
     override val name = "Cine24h"
-    override val baseUrl = "https://cine24h.online"
+    override val defaultBaseUrl = "https://cine24h.online"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
     override val logo = "https://i.ibb.co/kgjcsFmj/Image-1.png"
 
@@ -43,32 +52,61 @@ object Cine24hProvider : Provider {
 
     private suspend fun getDocument(url: String): Document {
         try {
-            // Tentativo ultra-veloce (3s) per rilevare se serve la WebView
             val client = NetworkClient.default.newBuilder()
-                .connectTimeout(3, TimeUnit.SECONDS)
-                .readTimeout(3, TimeUnit.SECONDS)
-                .writeTimeout(3, TimeUnit.SECONDS)
+                .connectTimeout(8, TimeUnit.SECONDS)
+                .readTimeout(12, TimeUnit.SECONDS)
+                .writeTimeout(12, TimeUnit.SECONDS)
+                .callTimeout(20, TimeUnit.SECONDS)
                 .build()
 
             val request = Request.Builder()
                 .url(url)
+                .header(
+                    "User-Agent",
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                )
+                .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                .header("Accept-Language", "es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7")
                 .header("Referer", baseUrl)
+                .header("Origin", baseUrl.trimEnd('/'))
                 .build()
-            
-            val response = client.newCall(request).execute()
-            
-            if (response.isSuccessful) {
-                val html = response.body?.string() ?: ""
-                // Se non c'è traccia di Cloudflare, procediamo con OkHttp (veloce)
-                if (!html.contains("cf-browser-verification") && !html.contains("Checking your browser") && !html.contains("Just a moment...")) {
-                    return Jsoup.parse(html).apply { setBaseUri(baseUrl) }
+
+            client.newCall(request).execute().use { response ->
+                val html = response.body?.string().orEmpty()
+                when {
+                    response.code == 403 ||
+                        html.contains("captcha", ignoreCase = true) ||
+                        html.contains("cf-browser-verification", ignoreCase = true) ||
+                        html.contains("Just a moment", ignoreCase = true) ||
+                        html.contains("Checking your browser", ignoreCase = true) -> {
+                        Log.d(TAG, "[Provider] Cloudflare/captcha detected for $url (HTTP ${response.code})")
+                    }
+                    response.isSuccessful && html.isNotBlank() -> {
+                        return Jsoup.parse(html).apply { setBaseUri(baseUrl) }
+                    }
+                    else -> {
+                        Log.w(TAG, "[Provider] Unexpected HTTP ${response.code} for $url")
+                    }
                 }
             }
-        } catch (_: Exception) { }
+        } catch (e: Exception) {
+            Log.w(TAG, "[Provider] OkHttp failed for $url: ${e.message}")
+        }
 
-        // Se OkHttp fallisce o rileva blocco, passiamo SUBITO alla WebView
         Log.d(TAG, "[Provider] Launching WebView Bypass for $url")
-        val html = getResolver().get(url)
+        val html = try {
+            getResolver().get(url)
+        } catch (e: Exception) {
+            throw Exception(
+                "Cine24h bloqueado (captcha/Cloudflare/forbidden). No se pudo cargar $url: ${e.message}"
+            )
+        }
+        if (html.isBlank() ||
+            html.contains("Just a moment", ignoreCase = true) ||
+            html.contains("captcha", ignoreCase = true)
+        ) {
+            throw Exception("Cine24h sigue bloqueado por captcha o Cloudflare. Prueba más tarde o cambia la URL del proveedor.")
+        }
         return Jsoup.parse(html).apply { setBaseUri(baseUrl) }
     }
 
@@ -76,28 +114,31 @@ object Cine24hProvider : Provider {
         val categories = mutableListOf<Category>()
         coroutineScope {
             try {
-                // Caricamento parallelo istantaneo delle sezioni
                 val bannerAsync = async { getDocument("$baseUrl/release/2025/") }
                 val moviesAsync = async { getDocument("$baseUrl/estrenos/?type=movies") }
                 val tvAsync = async { getDocument("$baseUrl/estrenos/?type=series") }
 
                 val bannerDoc = bannerAsync.await()
                 val bannerItems = parseShows(bannerDoc)
-                val featured = bannerItems.mapNotNull { 
-                    if (it is Movie) it.copy(poster = null, banner = it.poster) 
-                    else if (it is TvShow) it.copy(poster = null, banner = it.poster) 
-                    else null 
+                val featured = bannerItems.mapNotNull {
+                    if (it is Movie) it.copy(poster = null, banner = it.poster)
+                    else if (it is TvShow) it.copy(poster = null, banner = it.poster)
+                    else null
                 }.take(10)
                 if (featured.isNotEmpty()) categories.add(Category(Category.FEATURED, featured))
 
                 val movies = parseShows(moviesAsync.await()).filterIsInstance<Movie>()
-                if (movies.isNotEmpty()) categories.add(Category("Estrenos de Películas", movies)) 
-                
+                if (movies.isNotEmpty()) categories.add(Category("Estrenos de Películas", movies))
+
                 val tvShows = parseShows(tvAsync.await()).filterIsInstance<TvShow>()
-                if (tvShows.isNotEmpty()) categories.add(Category("Estrenos de Series", tvShows)) 
-                
+                if (tvShows.isNotEmpty()) categories.add(Category("Estrenos de Series", tvShows))
+
+                if (categories.isEmpty()) {
+                    throw Exception("Cine24h no devolvió contenido (posible captcha/forbidden)")
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "[Provider] Error loading home", e)
+                throw e
             }
         }
         return@withLock categories

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/CineCalidadProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/CineCalidadProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -17,10 +22,17 @@ import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 
-object CineCalidadProvider : Provider {
+object CineCalidadProvider : Provider, ProviderConfigUrl {
 
     override val name = "CineCalidad"
-    override val baseUrl = "https://www.cinecalidad.ec"
+    override val defaultBaseUrl = "https://www.cinecalidad.ec"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
     override val logo = "https://www.cinecalidad.ec/wp-content/themes/Cinecalidad/assets/img/logo.png"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/CineCityProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/CineCityProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -7,10 +12,17 @@ import com.dskja.betterstreamflix.models.*
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 
-object CineCityProvider : IptvProvider {
+object CineCityProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "MAGISTV"
-    override val baseUrl = "https://raw.githubusercontent.com"
+    override val defaultBaseUrl = "https://raw.githubusercontent.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/39Ld2wbt/MAGISTV.png"
     override val language = "es"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/CineHaxProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/CineHaxProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.net.Uri
 import android.util.Log
 import androidx.media3.common.MimeTypes
@@ -21,10 +26,17 @@ import java.util.concurrent.TimeUnit
  * language -> server label -> real embed URL (remux.unlimplay.com is a first-party direct MP4
  * CDN; the rest are hosts already covered by the shared [Extractor] system).
  */
-object CineHaxProvider : Provider {
+object CineHaxProvider : Provider, ProviderConfigUrl {
 
     override val name = "CineHax"
-    override val baseUrl = "https://cinehax.com"
+    override val defaultBaseUrl = "https://cinehax.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://cinehax.com/wp-content/uploads/2026/06/cropped-favicon-192x192.jpg"
     override val language = "es"
 
@@ -78,11 +90,16 @@ object CineHaxProvider : Provider {
         .connectTimeout(15, TimeUnit.SECONDS)
         .readTimeout(15, TimeUnit.SECONDS)
         .addInterceptor { chain ->
-            val request = chain.request().newBuilder()
+            val original = chain.request()
+            val request = original.newBuilder()
                 .header(
                     "User-Agent",
                     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
                 )
+                .header("Accept", "application/json,text/html,application/xhtml+xml,*/*;q=0.8")
+                .header("Accept-Language", "es-AR,es;q=0.9,en-US;q=0.8,en;q=0.7")
+                .header("Origin", baseUrl.trimEnd('/'))
+                .header("Referer", "${baseUrl.trimEnd('/')}/")
                 .build()
             chain.proceed(request)
         }
@@ -129,7 +146,8 @@ object CineHaxProvider : Provider {
     private fun humanizeKey(key: String) = key.replace('_', ' ').replaceFirstChar { it.uppercase() }
 
     override suspend fun getHome(): List<Category> {
-        val json = JSONObject(get("$baseUrl/wp-json/primeshow/v1/home-data"))
+        // Site moved from primeshow/v1 to cinehax/v1; Referer/Origin are required (403 otherwise).
+        val json = JSONObject(get("$baseUrl/wp-json/cinehax/v1/home-data"))
         val categories = mutableListOf<Category>()
         json.keys().forEach { key ->
             val items = json.optJSONArray(key) ?: return@forEach
@@ -137,6 +155,13 @@ object CineHaxProvider : Provider {
             if (shows.isNotEmpty()) {
                 categories.add(Category(name = HOME_CATEGORY_LABELS[key] ?: humanizeKey(key), list = shows))
             }
+        }
+        if (categories.isEmpty()) {
+            // Fallback if the REST shape changes again: scrape explore ajax pages.
+            val movies = fetchExplorePage("movie", 1)
+            val series = fetchExplorePage("tv", 1)
+            if (movies.isNotEmpty()) categories.add(Category("Películas populares", movies))
+            if (series.isNotEmpty()) categories.add(Category("Series populares", series))
         }
         return categories
     }

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/DoramasflixProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/DoramasflixProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
@@ -33,10 +38,17 @@ import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.util.Locale
 
-object DoramasflixProvider : Provider {
+object DoramasflixProvider : Provider, ProviderConfigUrl {
 
     override val name = "Doramasflix"
-    override val baseUrl = "https://doramasflix.in"
+    override val defaultBaseUrl = "https://doramasflix.in"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
     override val logo: String =
         "https://assets.seriesapi.co/brands/doramasflix/websites/6a651fa138cbd16df74343be/logo/logo-1785013866419.png"

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/EinschaltenProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/EinschaltenProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.models.Category
@@ -30,10 +35,18 @@ import org.json.JSONObject
 import org.json.JSONArray
 import java.util.concurrent.TimeUnit
 
-object EinschaltenProvider : Provider {
+object EinschaltenProvider : Provider, ProviderConfigUrl {
 
     override val name = "Einschalten"
-    override val baseUrl = "https://einschalten.in"
+    override val defaultBaseUrl = "https://einschalten.in"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        service = EinschaltenService.build(baseUrl.let { if (it.endsWith("/")) it else "$it/" })
+        baseUrl
+    }
     override val logo = "https://images2.imgbox.com/74/12/NBWU0dNi_o.png"
     override val language = "de"
 
@@ -81,7 +94,7 @@ object EinschaltenProvider : Provider {
         ): ResponseBody
     }
 
-    private val service = EinschaltenService.build(baseUrl)
+    private var service = EinschaltenService.build(defaultBaseUrl)
 
     private suspend fun getPosterUrl(movieId: String, posterPath: String): String {
         if (posterPath.isNotBlank()) {

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/FanpelisProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/FanpelisProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.google.gson.annotations.SerializedName
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -22,11 +27,18 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-object FanpelisProvider : Provider {
+object FanpelisProvider : Provider, ProviderConfigUrl {
     private const val URL = "https://fanpelis.to/"
     private const val API_URL = "https://fanpelis.to/api/rest/"
 
-    override val baseUrl = URL
+    override val defaultBaseUrl = "https://fanpelis.to/"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val name = "Fanpelis"
     override val logo = "https://fanpelis.to/wp-content/uploads/2025/02/cropped-play-button-icon-trendy-flat-260nw-752745979-e1738708582632-192x192.webp"
     override val language = "es"

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/FilmyOnlineCcProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/FilmyOnlineCcProvider.kt
@@ -1,5 +1,7 @@
 package com.dskja.betterstreamflix.providers
 
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.content.Context
 import android.util.Log
 import android.webkit.CookieManager
@@ -40,10 +42,17 @@ import java.text.Normalizer
 import java.util.concurrent.TimeUnit
 import okhttp3.Request
 
-object FilmyOnlineCcProvider : Provider {
+object FilmyOnlineCcProvider : Provider, ProviderConfigUrl {
 
     override val name = "FilmyOnline"
-    override val baseUrl = "https://filmyonline.cc"
+    override val defaultBaseUrl = "https://filmyonline.cc"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "$baseUrl/favicon/icon-144x144.png?v=1703232212"
     override val language = "pl"
 
@@ -78,9 +87,19 @@ object FilmyOnlineCcProvider : Provider {
                     return@withContext JSONObject(body)
                 }
 
-                if (response.code == 403 && clearanceRetries < MAX_API_CLEARANCE_RETRIES) {
-                    clearanceRetries++
-                    shouldRefreshClearance = true
+                if (response.code == 403 || response.code == 503) {
+                    val challenge = body.contains("Just a moment", ignoreCase = true) ||
+                        body.contains("cf-browser-verification", ignoreCase = true)
+                    if (challenge && clearanceRetries < MAX_API_CLEARANCE_RETRIES) {
+                        clearanceRetries++
+                        shouldRefreshClearance = true
+                    } else {
+                        throw Exception(
+                            "FilmyOnline API ${response.code}" +
+                                if (challenge) " (Cloudflare). Otwórz dostawcę ponownie, aby odświeżyć sesję."
+                                else ""
+                        )
+                    }
                 } else {
                     throw Exception("FilmyOnline API request failed: ${response.code}")
                 }
@@ -665,21 +684,32 @@ object FilmyOnlineCcProvider : Provider {
     private fun buildBrowserApiRequest(url: String, referer: String = "$baseUrl/"): Request {
         val cookieHeader = currentBrowserCookieHeader()
         val xsrfToken = resolveXsrfToken(cookieHeader)
+        val origin = baseUrl.trimEnd('/')
 
         return Request.Builder()
             .url(url)
+            .header(
+                "User-Agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+            )
+            .header("Accept", "application/json, text/plain, */*")
+            .header("Accept-Language", "pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7")
+            .header("Origin", origin)
             .header("Referer", referer)
-            .header("Accept", "application/json")
-            .header("Accept-Language", "it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7")
+            .header("X-Requested-With", "XMLHttpRequest")
             .header("Sec-Fetch-Dest", "empty")
             .header("Sec-Fetch-Mode", "cors")
             .header("Sec-Fetch-Site", "same-origin")
+            .header("Sec-CH-UA", "\"Chromium\";v=\"124\", \"Not-A.Brand\";v=\"99\", \"Google Chrome\";v=\"124\"")
+            .header("Sec-CH-UA-Mobile", "?0")
+            .header("Sec-CH-UA-Platform", "\"Windows\"")
             .apply {
                 if (!cookieHeader.isNullOrBlank()) {
                     header("Cookie", cookieHeader)
                 }
                 if (!xsrfToken.isNullOrBlank()) {
                     header("X-XSRF-TOKEN", xsrfToken)
+                    header("X-CSRF-TOKEN", xsrfToken)
                 }
             }
             .build()

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/FlixLatamProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/FlixLatamProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Log
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -28,14 +33,22 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 import java.util.Locale
 
-object FlixLatamProvider : Provider {
+object FlixLatamProvider : Provider, ProviderConfigUrl {
 
     override val name = "FlixLatam"
-    override val baseUrl = "https://flixlatam.com"
+    override val defaultBaseUrl = "https://flixlatam.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        service = FlixLatamService.build(baseUrl.let { if (it.endsWith("/")) it else "$it/" })
+        baseUrl
+    }
     override val language = "es"
     override val logo = "https://images2.imgbox.com/94/59/1ClPdx5Z_o.jpg"
 
-    private val service = FlixLatamService.build(baseUrl)
+    private var service = FlixLatamService.build(defaultBaseUrl)
     private val json = Json { ignoreUnknownKeys = true }
 
     override suspend fun getHome(): List<Category> = coroutineScope {
@@ -417,13 +430,21 @@ object FlixLatamProvider : Provider {
                 val okHttpClient = OkHttpClient.Builder()
                     .addInterceptor { chain ->
                         val request = chain.request().newBuilder()
-                            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36")
+                            .header(
+                                "User-Agent",
+                                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                            )
+                            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                            .header("Accept-Language", "es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7")
+                            .header("Referer", baseUrl)
+                            .header("Origin", baseUrl.trimEnd('/'))
                             .build()
                         chain.proceed(request)
                     }
                     .cache(Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024))
-                    .readTimeout(30, TimeUnit.SECONDS)
-                    .connectTimeout(30, TimeUnit.SECONDS)
+                    .readTimeout(20, TimeUnit.SECONDS)
+                    .connectTimeout(15, TimeUnit.SECONDS)
+                    .callTimeout(35, TimeUnit.SECONDS)
                     .dns(DnsResolver.doh)
                     .build()
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/FrembedProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/FrembedProvider.kt
@@ -46,7 +46,7 @@ object FrembedProvider : Provider, ProviderPortalUrl, ProviderConfigUrl {
             return cachePortalURL.ifEmpty { field }
         }
 
-    override val defaultBaseUrl: String = "https://frembed.casa/"
+    override val defaultBaseUrl: String = "https://frembed.surf/"
     override val baseUrl: String = defaultBaseUrl
         get() {
             val cacheURL = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL)
@@ -441,7 +441,10 @@ object FrembedProvider : Provider, ProviderPortalUrl, ProviderConfigUrl {
     }
 
     override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
-        return FrembedExtractor(baseUrl).servers(videoType)
+        val resolvedBase = baseUrl.ifBlank { defaultBaseUrl }.let {
+            if (it.endsWith("/")) it else "$it/"
+        }
+        return FrembedExtractor(resolvedBase).servers(videoType)
     }
 
     /**

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/FrenchAnimeProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/FrenchAnimeProvider.kt
@@ -33,7 +33,8 @@ import retrofit2.http.Path
 
 object FrenchAnimeProvider : Provider, ProviderConfigUrl {
     override val defaultBaseUrl: String = "https://french-anime.com/"
-    override val baseUrl: String = FrenchAnimeProvider.defaultBaseUrl
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
         get() {
             val cacheURL = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL)
             return cacheURL.ifEmpty { field }

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/FrenchMangaProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/FrenchMangaProvider.kt
@@ -43,7 +43,8 @@ object FrenchMangaProvider : Provider, ProviderPortalUrl, ProviderConfigUrl {
             val cachePortalURL = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_PORTAL_URL)
             return cachePortalURL.ifEmpty { field }
         }
-    override val baseUrl: String = FrenchMangaProvider.defaultBaseUrl
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
         get() {
             val cacheURL = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL)
             return cacheURL.ifEmpty { field }

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/GuardaFlixProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/GuardaFlixProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.models.Category
@@ -29,10 +34,18 @@ import java.util.concurrent.TimeUnit
 import java.net.URLEncoder
 import java.util.Base64
 
-object GuardaFlixProvider : Provider {
+object GuardaFlixProvider : Provider, ProviderConfigUrl {
 
     override val name: String = "GuardaFlix"
-    override val baseUrl: String = "https://guardaplay.store"
+    override val defaultBaseUrl = "https://guardaflix.org"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        service = GuardaFlixService.build(baseUrl.let { if (it.endsWith("/")) it else "$it/" })
+        baseUrl
+    }
     override val logo: String = "$baseUrl/wp-content/uploads/2021/05/cropped-Guarda-Flix-2.png"
     override val language: String = "it"
 
@@ -42,8 +55,22 @@ object GuardaFlixProvider : Provider {
         companion object {
             fun build(baseUrl: String): GuardaFlixService {
                 val clientBuilder = OkHttpClient.Builder()
-                    .readTimeout(30, TimeUnit.SECONDS)
-                    .connectTimeout(30, TimeUnit.SECONDS)
+                    .readTimeout(20, TimeUnit.SECONDS)
+                    .connectTimeout(15, TimeUnit.SECONDS)
+                    .callTimeout(35, TimeUnit.SECONDS)
+                    .addInterceptor { chain ->
+                        val request = chain.request().newBuilder()
+                            .header(
+                                "User-Agent",
+                                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                            )
+                            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                            .header("Accept-Language", "it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7")
+                            .header("Referer", baseUrl)
+                            .header("Origin", baseUrl.trimEnd('/'))
+                            .build()
+                        chain.proceed(request)
+                    }
 
                 return Retrofit.Builder()
                     .baseUrl(baseUrl)
@@ -75,7 +102,7 @@ object GuardaFlixProvider : Provider {
         suspend fun movies(@Path("page") page: Int): Document
     }
 
-    private val service = GuardaFlixService.build(baseUrl)
+    private var service = GuardaFlixService.build(defaultBaseUrl)
 
     private fun normalizeUrl(url: String): String {
         return when {
@@ -287,34 +314,47 @@ object GuardaFlixProvider : Provider {
 
     override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
         val doc = service.getPage(id)
+        val servers = mutableListOf<Video.Server>()
 
-        return doc.select("#aa-options div[id^=options-]").mapIndexedNotNull { index, optionDiv ->
-            val rawIframe = optionDiv.selectFirst("iframe[data-src]")?.attr("data-src")
-                ?: optionDiv.selectFirst("iframe")?.attr("src")
-                ?: return@mapIndexedNotNull null
-
-            val firstUrl = rawIframe.trim()
+        fun addEmbed(raw: String?, index: Int, label: String? = null) {
+            val firstUrl = raw?.trim().orEmpty()
+            if (firstUrl.isBlank()) return
             try {
                 val embedDoc = service.getPage(firstUrl)
-                val finalIframe = embedDoc.selectFirst(".Video iframe[src]")?.attr("src")?.trim()
-                val finalUrl = finalIframe?.takeIf { it.isNotBlank() } ?: return@mapIndexedNotNull null
-
-                val hostName = finalUrl.toHttpUrl().host
-                    .replaceFirst("www.", "")
-                    .substringBefore(".")
-                    .replaceFirstChar { char -> if (char.isLowerCase()) char.titlecase() else char.toString() }
-
-                val serverName = "Opzione ${index + 1} - $hostName"
-
-                Video.Server(
-                    id = finalUrl,
-                    name = serverName,
-                    src = finalUrl
+                val finalIframe = embedDoc.selectFirst(".Video iframe[src], iframe[src], iframe[data-src]")
+                    ?.let { it.attr("src").ifBlank { it.attr("data-src") } }
+                    ?.trim()
+                    ?: firstUrl
+                val hostName = runCatching {
+                    finalIframe.toHttpUrl().host
+                        .replaceFirst("www.", "")
+                        .substringBefore(".")
+                        .replaceFirstChar { char -> if (char.isLowerCase()) char.titlecase() else char.toString() }
+                }.getOrDefault("Server")
+                servers += Video.Server(
+                    id = finalIframe,
+                    name = label ?: "Opzione ${index + 1} - $hostName",
+                    src = finalIframe
                 )
             } catch (_: Exception) {
-                null
+                servers += Video.Server(id = firstUrl, name = label ?: "Opzione ${index + 1}", src = firstUrl)
             }
         }
+
+        doc.select("#aa-options div[id^=options-]").forEachIndexed { index, optionDiv ->
+            val rawIframe = optionDiv.selectFirst("iframe[data-src]")?.attr("data-src")
+                ?: optionDiv.selectFirst("iframe")?.attr("src")
+            addEmbed(rawIframe, index)
+        }
+
+        if (servers.isEmpty()) {
+            doc.select("iframe[src], iframe[data-src], li[data-src], .player iframe").forEachIndexed { index, el ->
+                val src = el.attr("data-src").ifBlank { el.attr("src") }
+                addEmbed(src, index)
+            }
+        }
+
+        return servers.distinctBy { it.src.ifBlank { it.id } }
     }
 
     override suspend fun getVideo(server: Video.Server): Video {

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/GuardaSerieProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/GuardaSerieProvider.kt
@@ -1,5 +1,7 @@
 package com.dskja.betterstreamflix.providers
 
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.content.Context
 import android.util.Log
 import android.webkit.CookieManager
@@ -38,10 +40,18 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-object GuardaSerieProvider : Provider {
+object GuardaSerieProvider : Provider, ProviderConfigUrl {
 
     override val name = "GuardaSerie"
-    override val baseUrl = "https://guardoserie.study"
+    override val defaultBaseUrl = "https://guardaserie.click/"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        service = GuardaSerieService.build(baseUrl.let { if (it.endsWith("/")) it else "$it/" })
+        baseUrl
+    }
     override val logo: String = "$baseUrl/wp-content/uploads/2026/06/Guardoserie1.png"
     override val language = "it"
 
@@ -119,7 +129,7 @@ object GuardaSerieProvider : Provider {
         suspend fun search(@Path("page") page: Int, @Query(value = "s", encoded = true) query: String): Document
     }
 
-    private val service = GuardaSerieService.build(baseUrl)
+    private var service = GuardaSerieService.build(defaultBaseUrl)
 
     private class CloudflareChallengeException(val url: String) : Exception("Cloudflare challenge detected for $url")
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/HDFilmeProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/HDFilmeProvider.kt
@@ -1,11 +1,14 @@
 package com.dskja.betterstreamflix.providers
 
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import com.dskja.betterstreamflix.models.Category
@@ -36,10 +39,18 @@ import retrofit2.http.Headers
 import retrofit2.http.Url
 import retrofit2.http.Path
 
-object HDFilmeProvider : Provider {
+object HDFilmeProvider : Provider, ProviderConfigUrl {
 
     override val name: String = "HDFilme"
-    override val baseUrl: String = "https://hdfilme.win"
+    override val defaultBaseUrl = "https://hdfilme.cafe/"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        service = HDFilmeService.build(baseUrl.let { if (it.endsWith("/")) it else "$it/" })
+        baseUrl
+    }
     override val logo: String = "$baseUrl/templates/hdfilme/images/apple-touch-icon.png"
     override val language: String = "de"
 
@@ -126,7 +137,7 @@ object HDFilmeProvider : Provider {
 
     }
 
-    private val service = HDFilmeService.build(baseUrl)
+    private var service = HDFilmeService.build(defaultBaseUrl)
     private data class SitemapEntry(val url: String, val searchableSlug: String)
 
     @Volatile private var sitemapEntries: List<SitemapEntry>? = null
@@ -968,18 +979,22 @@ object HDFilmeProvider : Provider {
             return servers.distinctBy { it.src }
         }
 
-        val iframeSrc = doc.selectFirst("iframe[src*='meinecloud.click']")?.attr("src")
+        val iframeSrc = doc.selectFirst(
+            "iframe[src*='meinecloud.click'], iframe[src*='meinecloud'], iframe[data-src*='meinecloud'], " +
+                "iframe[src*='cloud'], iframe.player-iframe, #player iframe, .player iframe"
+        )?.let { it.attr("src").ifBlank { it.attr("data-src") } }
+            ?: doc.selectFirst("iframe[src], iframe[data-src]")?.let { it.attr("src").ifBlank { it.attr("data-src") } }
             ?: throw Exception("Embed iframe not found")
 
         val embedUrl = normalizeUrl(iframeSrc)
         val embedDoc = service.getPage(embedUrl)
 
-        return embedDoc.select("ul._player-mirrors li[data-link]")
+        val mirrors = embedDoc.select("ul._player-mirrors li[data-link], li[data-link], .mirror-list li[data-link], a[data-link]")
             .filterNot { li ->
                 li.hasClass("fullhd") || li.text().contains("4K Server", ignoreCase = true)
             }
             .mapNotNull { li ->
-                val dataLink = li.attr("data-link").trim()
+                val dataLink = li.attr("data-link").trim().ifBlank { li.attr("href").trim() }
                 if (dataLink.isBlank()) return@mapNotNull null
 
                 val normalized = when {
@@ -994,6 +1009,11 @@ object HDFilmeProvider : Provider {
                 Video.Server(id = normalized, name = name, src = normalized)
             }
             .filter { it.src.isNotBlank() }
+
+        return mirrors.ifEmpty {
+            // Last resort: treat the embed page itself as a playable host.
+            listOf(Video.Server(id = embedUrl, name = "Embed", src = embedUrl))
+        }
     }
 
     override suspend fun getVideo(server: Video.Server): Video {

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/HiAnimeProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/HiAnimeProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -22,10 +27,17 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 import java.util.concurrent.TimeUnit
 
-object HiAnimeProvider : Provider {
+object HiAnimeProvider : Provider, ProviderConfigUrl {
 
     private const val URL = "https://hianime.cv/"
-    override val baseUrl = URL
+    override val defaultBaseUrl = "https://hianime.cv/"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val name = "HiAnime"
     override val logo = "$URL/images/logo.png"
     override val language = "en"

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/IptvOrgProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/IptvOrgProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -7,10 +12,17 @@ import com.dskja.betterstreamflix.models.*
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 
-object IptvOrgProvider : IptvProvider {
+object IptvOrgProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "IPTV-All World"
-    override val baseUrl = "https://iptv-org.github.io/iptv"
+    override val defaultBaseUrl = "https://iptv-org.github.io/iptv"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/W1d0CxF/Logo-IPTV-All-World.jpg"
     override val language = "en"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/IptvSpainProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/IptvSpainProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -7,10 +12,17 @@ import com.dskja.betterstreamflix.models.*
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 
-object IptvSpainProvider : IptvProvider {
+object IptvSpainProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "IPTV Spain"
-    override val baseUrl = "https://iptv-org.github.io/iptv/languages/spa.m3u"
+    override val defaultBaseUrl = "https://iptv-org.github.io/iptv/languages/spa.m3u"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/SD7860Mv/IPTV-Spain-Canales.jpg"
     override val language = "es"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/JKAnimeProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/JKAnimeProvider.kt
@@ -1,5 +1,7 @@
 package com.dskja.betterstreamflix.providers
 
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -33,10 +35,17 @@ import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Url
 
-object JKAnimeProvider : Provider {
+object JKAnimeProvider : Provider, ProviderConfigUrl {
 
     override val name = "JKAnime"
-    override val baseUrl = "https://jkanime.net"
+    override val defaultBaseUrl = "https://jkanime.net"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
     override val logo = "https://cdn.jkdesa.com/assets3/css/img/jkanimenet.png"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/LaCartoonsProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/LaCartoonsProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -26,10 +31,17 @@ import java.io.File
 import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 
-object LaCartoonsProvider : Provider {
+object LaCartoonsProvider : Provider, ProviderConfigUrl {
 
     override val name = "La Cartoons"
-    override val baseUrl = "https://www.lacartoons.com"
+    override val defaultBaseUrl = "https://www.lacartoons.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
     override val logo: String get() = "https://images2.imgbox.com/fc/26/S7f7dn42_o.png"
 
@@ -45,9 +57,23 @@ object LaCartoonsProvider : Provider {
         val appCache = Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024)
         val builder = OkHttpClient.Builder()
             .cache(appCache)
-            .readTimeout(30, TimeUnit.SECONDS)
-            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .callTimeout(35, TimeUnit.SECONDS)
             .followRedirects(true)
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header(
+                        "User-Agent",
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                    )
+                    .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                    .header("Accept-Language", "es-MX,es;q=0.9,en-US;q=0.8,en;q=0.7")
+                    .header("Referer", "$baseUrl/")
+                    .header("Origin", baseUrl.trimEnd('/'))
+                    .build()
+                chain.proceed(request)
+            }
         return builder.dns(DnsResolver.doh).build()
     }
 
@@ -233,26 +259,36 @@ object LaCartoonsProvider : Provider {
     override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
         val url = if (id.startsWith("http")) id else "$baseUrl$id"
         val doc = service.getPage(url)
-        val iframe = doc.selectFirst("iframe[src]")?.attr("src").orEmpty()
-        val finalUrl = if (iframe.startsWith("http")) iframe else "$iframe"
-        return listOfNotNull(
-            if (finalUrl.isNotBlank()) {
-                try {
-                    val serverName = finalUrl.toHttpUrl().host
-                        .replaceFirst("www.", "")
-                        .substringBefore(".")
-                        .replaceFirstChar { char -> if (char.isLowerCase()) char.titlecase() else char.toString() }
-                    
-                    Video.Server(
-                        id = finalUrl,
-                        name = serverName,
-                        src = finalUrl
-                    )
-                } catch (e: Exception) {
-                    null
-                }
-            } else null
-        )
+        val servers = mutableListOf<Video.Server>()
+
+        fun addServer(raw: String?, label: String?) {
+            val finalUrl = raw?.trim().orEmpty()
+            if (finalUrl.isBlank()) return
+            val absolute = when {
+                finalUrl.startsWith("//") -> "https:$finalUrl"
+                finalUrl.startsWith("http") -> finalUrl
+                else -> "$baseUrl/${finalUrl.trimStart('/')}"
+            }
+            val serverName = label?.takeIf { it.isNotBlank() } ?: runCatching {
+                absolute.toHttpUrl().host
+                    .replaceFirst("www.", "")
+                    .substringBefore(".")
+                    .replaceFirstChar { char -> if (char.isLowerCase()) char.titlecase() else char.toString() }
+            }.getOrDefault("Server")
+            servers += Video.Server(id = absolute, name = serverName, src = absolute)
+        }
+
+        doc.select("iframe[src], iframe[data-src], .embed iframe, #player iframe, .player iframe").forEach {
+            addServer(it.attr("src").ifBlank { it.attr("data-src") }, it.attr("title"))
+        }
+        doc.select("[data-src*=http], li[data-url], a[data-player]").forEach {
+            addServer(
+                it.attr("data-src").ifBlank { it.attr("data-url") }.ifBlank { it.attr("data-player") },
+                it.text()
+            )
+        }
+
+        return servers.distinctBy { it.src.ifBlank { it.id } }
     }
 
     override suspend fun getVideo(server: Video.Server): Video {

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/LatanimeProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/LatanimeProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -19,10 +24,17 @@ import retrofit2.http.Url
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-object LatanimeProvider : Provider {
+object LatanimeProvider : Provider, ProviderConfigUrl {
 
     override val name = "Latanime"
-    override val baseUrl = "https://latanime.org"
+    override val defaultBaseUrl = "https://latanime.org"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
 
     private val client = getOkHttpClient()

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/MEGAKinoProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/MEGAKinoProvider.kt
@@ -458,23 +458,28 @@ object MEGAKinoProvider : Provider, ProviderConfigUrl {
 
         if (videoType is Video.Type.Movie) {
             val document = getService().getDocument(absoluteUrl(id))
-            
-            val tabNames = document.select("div.tabs-block__select span").map { it.text() }
-            val contents = document.select("div.tabs-block__content")
-            
+
+            val tabNames = document.select("div.tabs-block__select span, .tabs-block__select span, .player-tabs span, .nav-tabs a")
+                .map { it.text().trim() }
+            val contents = document.select("div.tabs-block__content, .tabs-block__content, .tab-content .tab-pane, .player iframe")
+
             contents.forEachIndexed { index, content ->
-                val iframe = content.selectFirst("iframe")
-                val serverSrc = iframe?.attr("data-src")?.takeIf { it.isNotEmpty() } 
+                val iframe = content.takeIf { it.tagName() == "iframe" } ?: content.selectFirst("iframe")
+                val serverSrc = iframe?.attr("data-src")?.takeIf { it.isNotEmpty() }
                     ?: iframe?.attr("src")
-                
+
                 if (!serverSrc.isNullOrEmpty()) {
                     val serverName = tabNames.getOrNull(index)?.takeIf { it.isNotBlank() } ?: "Server ${index + 1}"
-                    servers.add(
-                        Video.Server(
-                            id = serverSrc,
-                            name = serverName
-                        )
-                    )
+                    servers.add(Video.Server(id = serverSrc, name = serverName, src = serverSrc))
+                }
+            }
+
+            if (servers.isEmpty()) {
+                document.select("iframe[src], iframe[data-src], [data-src*=http]").forEachIndexed { index, iframe ->
+                    val serverSrc = iframe.attr("data-src").ifBlank { iframe.attr("src") }
+                    if (serverSrc.isNotBlank()) {
+                        servers.add(Video.Server(id = serverSrc, name = "Server ${index + 1}", src = serverSrc))
+                    }
                 }
             }
         } else if (videoType is Video.Type.Episode) {
@@ -483,24 +488,27 @@ object MEGAKinoProvider : Provider, ProviderConfigUrl {
                 val pageUrl = parts[0]
                 val epId = parts[1]
                 val document = getService().getDocument(absoluteUrl(pageUrl))
-                
-                val select = document.select("select#$epId")
+
+                val select = document.select("select#$epId, select.episode-servers, select[name*=server]")
                 select.select("option").forEach { option ->
                     val serverUrl = option.attr("value")
                     val serverName = option.text()
-                    
                     if (serverUrl.isNotEmpty()) {
-                         servers.add(
-                            Video.Server(
-                                id = serverUrl,
-                                name = serverName
-                            )
-                        )
+                        servers.add(Video.Server(id = serverUrl, name = serverName, src = serverUrl))
+                    }
+                }
+
+                if (servers.isEmpty()) {
+                    document.select("iframe[src], iframe[data-src]").forEachIndexed { index, iframe ->
+                        val serverSrc = iframe.attr("data-src").ifBlank { iframe.attr("src") }
+                        if (serverSrc.isNotBlank()) {
+                            servers.add(Video.Server(id = serverSrc, name = "Server ${index + 1}", src = serverSrc))
+                        }
                     }
                 }
             }
         }
-        return servers
+        return servers.distinctBy { it.src.ifBlank { it.id } }
     }
 
     override suspend fun getVideo(server: Video.Server): Video {

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/MkissaProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/MkissaProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -39,7 +44,7 @@ import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
-object MkissaProvider : Provider {
+object MkissaProvider : Provider, ProviderConfigUrl {
 
     private const val TAG = "MkissaProvider"
     private const val API_URL = "https://api.allanime.day/"
@@ -218,7 +223,14 @@ object MkissaProvider : Provider {
     """.trimIndent()
 
     override val name = "MKissa"
-    override val baseUrl = "https://mkissa.to/anime"
+    override val defaultBaseUrl = "https://mkissa.to/anime"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "en"
     override val logo = "https://mkissa.to/favicon-32x32.png"
 
@@ -228,9 +240,22 @@ object MkissaProvider : Provider {
         .client(
             OkHttpClient.Builder()
                 .cache(Cache(File("cacheDir", "mkissa_okhttpcache"), 10 * 1024 * 1024))
-                .readTimeout(30, TimeUnit.SECONDS)
-                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(20, TimeUnit.SECONDS)
+                .connectTimeout(15, TimeUnit.SECONDS)
+                .callTimeout(35, TimeUnit.SECONDS)
                 .dns(DnsResolver.doh)
+                .addInterceptor { chain ->
+                    val request = chain.request().newBuilder()
+                        .header(
+                            "User-Agent",
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                        )
+                        .header("Accept", "application/json, text/plain, */*")
+                        .header("Origin", "https://mkissa.to")
+                        .header("Referer", "https://mkissa.to/")
+                        .build()
+                    chain.proceed(request)
+                }
                 .build()
         )
         .build()
@@ -418,6 +443,12 @@ object MkissaProvider : Provider {
             hash = SOURCE_HASH,
             fallbackQuery = SOURCE_QUERY
         )
+        if (response.hasAaCryptoError()) {
+            throw Exception(
+                "MKissa episode sources require aa-crypto bootstrap (AA_CRYPTO_MISSING). " +
+                    "Catalog still works; playback needs an updated crypto client."
+            )
+        }
         var data = response.optJSONObject("data") ?: JSONObject()
         if (data.has("tobeparsed")) {
             data = decryptTobeParsed(data.optString("tobeparsed"))
@@ -431,7 +462,6 @@ object MkissaProvider : Provider {
             .flatMap { it.asSequence() }
             .mapNotNull { it as? JSONObject }
             .filter { it.sourceUrl().isNotBlank() }
-//            .filterNot { it.isKnownDeadEmbedSource() }
             .toList()
     }
 
@@ -700,11 +730,23 @@ object MkissaProvider : Provider {
         return errors.asSequence()
             .mapNotNull { it as? JSONObject }
             .any { error ->
-                error.optString("message").contains("PersistedQueryNotFound", ignoreCase = true) ||
-                    error.optString("message").contains("PersistedQueryNotSupported", ignoreCase = true) ||
-                    error.optJSONObject("extensions")
-                        ?.optString("code")
-                        ?.contains("PERSISTED_QUERY", ignoreCase = true) == true
+                val message = error.optString("message")
+                val code = error.optJSONObject("extensions")?.optString("code").orEmpty()
+                message.contains("PersistedQueryNotFound", ignoreCase = true) ||
+                    message.contains("PersistedQueryNotSupported", ignoreCase = true) ||
+                    code.contains("PERSISTED_QUERY", ignoreCase = true)
+            }
+    }
+
+    private fun JSONObject.hasAaCryptoError(): Boolean {
+        val errors = optJSONArray("errors") ?: return false
+        return errors.asSequence()
+            .mapNotNull { it as? JSONObject }
+            .any { error ->
+                val message = error.optString("message")
+                val code = error.optJSONObject("extensions")?.optString("code").orEmpty()
+                message.contains("AA_CRYPTO", ignoreCase = true) ||
+                    code.contains("AA_CRYPTO", ignoreCase = true)
             }
     }
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/OtakufrProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/OtakufrProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -25,10 +30,17 @@ import retrofit2.http.Query
 import retrofit2.http.Url
 import java.util.concurrent.TimeUnit
 
-object OtakufrProvider : Provider {
+object OtakufrProvider : Provider, ProviderConfigUrl {
 
     private const val URL = "https://otakufr.cc/"
-    override val baseUrl = URL
+    override val defaultBaseUrl = "https://otakufr.cc/"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val name = "Otakufr"
     override val logo = "https://i.ibb.co/GndKBbF/otakufr-logo.webp"
     override val language = "fr"

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/PelisflixHdProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/PelisflixHdProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -24,10 +29,17 @@ import java.net.URLDecoder
 import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 
-object PelisflixHdProvider : Provider {
+object PelisflixHdProvider : Provider, ProviderConfigUrl {
 
     override val name = "PelisflixHD"
-    override val baseUrl = "https://pelisflixhd.win"
+    override val defaultBaseUrl = "https://pelisflixhd.win"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
     override val logo = "https://s.pelisflixhd.win/cat/logo-mini.png"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/PelisplustoProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/PelisplustoProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
@@ -27,10 +32,17 @@ import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.delay
 
-object PelisplustoProvider : Provider {
+object PelisplustoProvider : Provider, ProviderConfigUrl {
 
     override val name = "Pelisplusto"
-    override val baseUrl = "https://pelisplus.to"
+    override val defaultBaseUrl = "https://pelisplushd.bz/"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
     override val logo = "https://pelisplus.to/images/logo2.png"
     private const val TAG = "PelisplustoProvider"

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/PelotaLibreTvHdProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/PelotaLibreTvHdProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -7,10 +12,17 @@ import com.dskja.betterstreamflix.models.*
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 
-object PelotaLibreTvHdProvider : IptvProvider {
+object PelotaLibreTvHdProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "Sports Events"
-    override val baseUrl = "https://raw.githubusercontent.com"
+    override val defaultBaseUrl = "https://raw.githubusercontent.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     // Logo genérico de deportes
     override val logo = "https://i.ibb.co/3s2mhm6/sports-logo.png"
     override val language = "es"

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvArProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvArProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -7,10 +12,17 @@ import com.dskja.betterstreamflix.models.*
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 
-object PlutoTvArProvider : IptvProvider {
+object PlutoTvArProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "Pluto TV Ar"
-    override val baseUrl = "https://raw.githubusercontent.com"
+    override val defaultBaseUrl = "https://raw.githubusercontent.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/jPsc2PMd/Logo-Pluto-TV-AR.jpg"
     override val language = "es"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvDeProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvDeProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -7,10 +12,17 @@ import com.dskja.betterstreamflix.models.*
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 
-object PlutoTvDeProvider : IptvProvider {
+object PlutoTvDeProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "Pluto TV De"
-    override val baseUrl = "https://raw.githubusercontent.com"
+    override val defaultBaseUrl = "https://raw.githubusercontent.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/qz7jJF1/plutotv.png"
     override val language = "de"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvEsProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvEsProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -7,10 +12,17 @@ import com.dskja.betterstreamflix.models.*
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 
-object PlutoTvEsProvider : IptvProvider {
+object PlutoTvEsProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "Pluto TV Es"
-    override val baseUrl = "https://raw.githubusercontent.com"
+    override val defaultBaseUrl = "https://raw.githubusercontent.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/TBjWz2Zw/Pluto-TV-es.jpg"
     override val language = "es"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvFrProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvFrProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -7,10 +12,17 @@ import com.dskja.betterstreamflix.models.*
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 
-object PlutoTvFrProvider : IptvProvider {
+object PlutoTvFrProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "Pluto TV FR"
-    override val baseUrl = "https://raw.githubusercontent.com"
+    override val defaultBaseUrl = "https://raw.githubusercontent.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/qz7jJF1/plutotv.png"
     override val language = "fr"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvItProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvItProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -7,10 +12,17 @@ import com.dskja.betterstreamflix.models.*
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 
-object PlutoTvItProvider : IptvProvider {
+object PlutoTvItProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "Pluto TV It"
-    override val baseUrl = "https://raw.githubusercontent.com"
+    override val defaultBaseUrl = "https://raw.githubusercontent.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/qz7jJF1/plutotv.png"
     override val language = "it"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvMxProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvMxProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -7,10 +12,17 @@ import com.dskja.betterstreamflix.models.*
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 
-object PlutoTvMxProvider : IptvProvider {
+object PlutoTvMxProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "Pluto TV MX"
-    override val baseUrl = "https://raw.githubusercontent.com"
+    override val defaultBaseUrl = "https://raw.githubusercontent.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/9mGNwYVS/Logo-Pluto-TV.jpg"
     override val language = "es"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvUsProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/PlutoTvUsProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -7,10 +12,17 @@ import com.dskja.betterstreamflix.models.*
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 
-object PlutoTvUsProvider : IptvProvider {
+object PlutoTvUsProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "Pluto TV Us"
-    override val baseUrl = "https://raw.githubusercontent.com"
+    override val defaultBaseUrl = "https://raw.githubusercontent.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/qz7jJF1/plutotv.png"
     override val language = "en"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/RidomoviesProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/RidomoviesProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -28,10 +33,17 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import java.util.concurrent.TimeUnit
 
-object RidomoviesProvider : Provider {
+object RidomoviesProvider : Provider, ProviderConfigUrl {
 
     const val URL = "https://ridomovies.su/"
-    override val baseUrl = URL
+    override val defaultBaseUrl = "https://ridomovies.su/"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val name = "Ridomovies"
     override val logo = "$URL/uploads/logos/hero_logo-1-1769040020-ab537326.png"
     override val language = "en"
@@ -386,12 +398,12 @@ object RidomoviesProvider : Provider {
 
         fun extractIframeSrc(rawHtml: String): String? {
             if (rawHtml.isBlank()) return null
-            val iframe = Jsoup.parse(rawHtml).selectFirst("iframe")
-            return iframe?.attr("src")
+            val iframe = org.jsoup.Jsoup.parse(rawHtml).selectFirst("iframe")
+            return iframe?.attr("src")?.ifBlank { iframe.attr("data-src") }
         }
 
         // #player-cover is always present (movies and episodes)
-        document.selectFirst("#player-cover[data-embed]")?.let { el ->
+        document.selectFirst("#player-cover[data-embed], [data-embed]")?.let { el ->
             val src = extractIframeSrc(el.attr("data-embed"))
             if (!src.isNullOrBlank()) {
                 servers.add(Video.Server(id = src, name = "Server 1", src = src))
@@ -399,15 +411,48 @@ object RidomoviesProvider : Provider {
         }
 
         // Dropdown buttons appear only on multi-server movies — add extras deduplicating against player-cover
-        document.select(".server-dropdown-item[data-server-embed]").forEachIndexed { idx, btn ->
-            val src = extractIframeSrc(btn.attr("data-server-embed"))
+        document.select(".server-dropdown-item[data-server-embed], [data-server-embed], .servers a[data-embed]").forEachIndexed { idx, btn ->
+            val src = extractIframeSrc(btn.attr("data-server-embed").ifBlank { btn.attr("data-embed") })
             val label = btn.text().ifBlank { "Server ${idx + 1}" }
             if (!src.isNullOrBlank() && servers.none { it.src == src }) {
                 servers.add(Video.Server(id = src, name = label, src = src))
             }
         }
 
-        return servers
+        if (servers.isEmpty()) {
+            document.select("iframe[src], iframe[data-src]").forEachIndexed { idx, iframe ->
+                val src = iframe.attr("src").ifBlank { iframe.attr("data-src") }
+                if (src.isNotBlank()) {
+                    servers.add(Video.Server(id = src, name = "Server ${idx + 1}", src = src))
+                }
+            }
+        }
+
+        // Some pages stash embeds in inline scripts / data attributes.
+        if (servers.isEmpty()) {
+            val html = document.html()
+            Regex(
+                """(?:data-(?:server-)?embed|src)\s*[:=]\s*["'](https?://[^"']+)["']""",
+                RegexOption.IGNORE_CASE,
+            ).findAll(html).forEachIndexed { idx, match ->
+                val src = match.groupValues.getOrNull(1).orEmpty()
+                if (src.isNotBlank() && servers.none { it.src == src }) {
+                    servers.add(Video.Server(id = src, name = "Embed ${idx + 1}", src = src))
+                }
+            }
+        }
+
+        if (servers.isEmpty()) {
+            val html = document.html()
+            if (html.contains("Just a moment", ignoreCase = true) ||
+                html.contains("cf-mitigated", ignoreCase = true) ||
+                html.contains("challenge-platform", ignoreCase = true)
+            ) {
+                throw Exception("Ridomovies blocked by Cloudflare; open the site on-device to clear challenge")
+            }
+        }
+
+        return servers.distinctBy { it.src.ifBlank { it.id } }
     }
 
     override suspend fun getVideo(server: Video.Server): Video {
@@ -440,12 +485,23 @@ object RidomoviesProvider : Provider {
                     .addInterceptor { chain ->
                         val request = chain.request().newBuilder()
                             .addHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-                            .addHeader("Accept-Language", "en-US,en;q=0.5")
-                            .addHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36")
+                            .addHeader("Accept-Language", "en-US,en;q=0.9")
+                            .addHeader(
+                                "User-Agent",
+                                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+                            )
+                            .addHeader("Referer", URL)
+                            .addHeader("Origin", URL.trimEnd('/'))
+                            .addHeader("Sec-CH-UA", "\"Chromium\";v=\"131\", \"Not-A.Brand\";v=\"24\", \"Google Chrome\";v=\"131\"")
+                            .addHeader("Sec-CH-UA-Mobile", "?0")
+                            .addHeader("Sec-CH-UA-Platform", "\"Windows\"")
                             .addHeader("Platform", "android")
                             .build()
                         chain.proceed(request)
                     }
+                    .connectTimeout(15, TimeUnit.SECONDS)
+                    .readTimeout(20, TimeUnit.SECONDS)
+                    .callTimeout(35, TimeUnit.SECONDS)
                     .build()
 
                 val retrofit = Retrofit.Builder()

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/SeriesFlixProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/SeriesFlixProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -27,10 +32,17 @@ import java.net.URLDecoder
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-object SeriesFlixProvider : Provider {
+object SeriesFlixProvider : Provider, ProviderConfigUrl {
 
     override val name = "SeriesFlix"
-    override val baseUrl = "https://seriesflixhd.lol"
+    override val defaultBaseUrl = "https://seriesflixhd.lol"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://s.seriesflixhd.lol/series/imgs/favicon-192.png"
     override val language = "es"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/SeriesTurcasProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/SeriesTurcasProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
 import com.dskja.betterstreamflix.extractors.GenericPackedSourceExtractor
@@ -27,10 +32,17 @@ import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
-object SeriesTurcasProvider : Provider {
+object SeriesTurcasProvider : Provider, ProviderConfigUrl {
 
     override val name = "Series Turcas"
-    override val baseUrl = "https://tbg.seriesturcastv.to"
+    override val defaultBaseUrl = "https://tbg.seriesturcastv.to"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = artworkUrl(
         "$baseUrl/wp-content/uploads/2021/04/favicon.png",
         "$baseUrl/home/"

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/SflixProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/SflixProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.BuildConfig
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -25,10 +30,17 @@ import retrofit2.http.Query
 import retrofit2.http.Url
 import java.util.concurrent.TimeUnit
 
-object SflixProvider : Provider {
+object SflixProvider : Provider, ProviderConfigUrl {
 
     private const val URL = "https://sflix.to/"
-    override val baseUrl = URL
+    override val defaultBaseUrl = "https://sflix.to/"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val name = "SFlix"
     override val logo = "https://img.sflix.to/xxrz/400x400/100/66/35/66356c25ce98cb12993249e21742b129/66356c25ce98cb12993249e21742b129.png"
     override val language = "en"
@@ -37,7 +49,11 @@ object SflixProvider : Provider {
 
 
     override suspend fun getHome(): List<Category> {
-        val document = service.getHome()
+        val document = try {
+            service.getHome()
+        } catch (e: Exception) {
+            throw Exception("SFlix home timed out or is unreachable (${e.message}). Try again or change the provider URL.")
+        }
 
         val categories = mutableListOf<Category>()
 
@@ -733,9 +749,23 @@ object SflixProvider : Provider {
         companion object {
             fun build(): SflixService {
                 val client = OkHttpClient.Builder()
-                    .readTimeout(30, TimeUnit.SECONDS)
-                    .connectTimeout(30, TimeUnit.SECONDS)
+                    .connectTimeout(12, TimeUnit.SECONDS)
+                    .readTimeout(15, TimeUnit.SECONDS)
+                    .writeTimeout(15, TimeUnit.SECONDS)
+                    .callTimeout(25, TimeUnit.SECONDS)
                     .dns(DnsResolver.doh)
+                    .addInterceptor { chain ->
+                        val request = chain.request().newBuilder()
+                            .header(
+                                "User-Agent",
+                                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                            )
+                            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                            .header("Accept-Language", "en-US,en;q=0.9")
+                            .header("Referer", URL)
+                            .build()
+                        chain.proceed(request)
+                    }
                     .build()
 
                 val retrofit = Retrofit.Builder()

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/SoloLatinoProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/SoloLatinoProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -33,10 +38,17 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.Dispatchers
 
 
-object SoloLatinoProvider : Provider {
+object SoloLatinoProvider : Provider, ProviderConfigUrl {
 
     override val name = "SoloLatino"
-    override val baseUrl = "https://sololatino.net"
+    override val defaultBaseUrl = "https://sololatino.net"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "es"
 
     private val client = getOkHttpClient()
@@ -55,14 +67,22 @@ object SoloLatinoProvider : Provider {
         val clientBuilder = OkHttpClient.Builder()
             .addInterceptor { chain ->
                 val request = chain.request().newBuilder()
-                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36")
+                    .header(
+                        "User-Agent",
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                    )
+                    .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                    .header("Accept-Language", "es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7")
+                    .header("Referer", "$baseUrl/")
+                    .header("Origin", baseUrl.trimEnd('/'))
                     .build()
                 chain.proceed(request)
             }
             .cookieJar(MyCookieJar())
             .cache(appCache)
-            .readTimeout(30, TimeUnit.SECONDS)
-            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .callTimeout(35, TimeUnit.SECONDS)
 
         return clientBuilder.dns(DnsResolver.doh).build()
     }
@@ -75,18 +95,18 @@ object SoloLatinoProvider : Provider {
 
     override val logo = "$baseUrl/images/logo.png"
 
-    override suspend fun getHome(): List<Category> = coroutineScope {
+            override suspend fun getHome(): List<Category> = coroutineScope {
         val categories = mutableListOf<Category>()
 
         try {
             val mainDoc = service.getPage(baseUrl)
-            
+
             // 1. Featured
             val bannerShows = parseBannerShows(mainDoc).take(12)
             if (bannerShows.isNotEmpty()) {
                 categories.add(Category(Category.FEATURED, bannerShows))
             }
-            
+
             // 2. Sections from the home page
             val sections = mainDoc.select("section")
             for (section in sections) {
@@ -96,7 +116,13 @@ object SoloLatinoProvider : Provider {
                     categories.add(Category(title, shows.take(12)))
                 }
             }
-        } catch (e: Exception) { /* Ignore */ }
+
+            if (categories.isEmpty()) {
+                throw Exception("SoloLatino home vacío (posible Cloudflare 403)")
+            }
+        } catch (e: Exception) {
+            throw Exception("SoloLatino: ${e.message}")
+        }
 
         categories
     }

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/StreamingItaProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/StreamingItaProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.models.Category
@@ -40,10 +45,17 @@ import java.net.URLDecoder
 import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 
-object StreamingItaProvider : Provider {
+object StreamingItaProvider : Provider, ProviderConfigUrl {
 
     override val name = "StreamingIta"
-    override val baseUrl = "https://streamingita.homes"
+    override val defaultBaseUrl = "https://streamingita.homes"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val language = "it"
     override val logo: String get() = "$baseUrl/wp-content/uploads/2019/204/logos.png"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/TioAnimeProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/TioAnimeProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.Extractor
 import com.dskja.betterstreamflix.models.*
@@ -12,9 +17,16 @@ import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Url
 
-object TioAnimeProvider : Provider {
+object TioAnimeProvider : Provider, ProviderConfigUrl {
     override val name = "TioAnime"
-    override val baseUrl = "https://tioanime.com"
+    override val defaultBaseUrl = "https://tioanime.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "$baseUrl/assets/img/logo-dark.png"
     override val language = "es"
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/TmdbProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/TmdbProvider.kt
@@ -1,5 +1,6 @@
 package com.dskja.betterstreamflix.providers
 
+import com.dskja.betterstreamflix.BuildConfig
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.extractors.AfterDarkExtractor
 import com.dskja.betterstreamflix.extractors.Extractor
@@ -52,6 +53,7 @@ class TmdbProvider(override val language: String) : Provider {
 
     override suspend fun getHome(): List<Category> = coroutineScope {
         try {
+            requireTmdbApiKey()
             buildHomeCategories()
         } catch (e: Exception) {
             Log.e("TmdbProvider", "TMDB home failed: ${e.message}", e)
@@ -60,6 +62,17 @@ class TmdbProvider(override val language: String) : Provider {
                     "Check your connection or switch DNS over HTTPS in Settings. " +
                     "(${e.message})",
                 e
+            )
+        }
+    }
+
+    
+    private fun requireTmdbApiKey() {
+        val key = UserPreferences.tmdbApiKey.ifBlank { BuildConfig.TMDB_API_KEY }.trim()
+        if (key.isBlank() || key == "null") {
+            throw Exception(
+                "TMDb API key is missing. Open Settings → enter your TMDb API key " +
+                    "(https://www.themoviedb.org/settings/api), then try again."
             )
         }
     }

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/TvLibrefutbolProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/TvLibrefutbolProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Base64
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
@@ -26,10 +31,17 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import kotlin.collections.filter
 
-object TvLibrefutbolProvider : IptvProvider {
+object TvLibrefutbolProvider : IptvProvider, ProviderConfigUrl {
 
     override val name = "Tv Libre Futbol"
-    override val baseUrl = "https://www.librefutbol2.com"
+    override val defaultBaseUrl = "https://www.librefutbol2.com"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo = "https://i.ibb.co/q3v6R9qQ/librefutbol.jpg"
     override val language = "es"
 
@@ -404,21 +416,31 @@ object TvLibrefutbolProvider : IptvProvider {
             val doc = fetchDocument(id) ?: throw Exception("No se pudo cargar")
             val servers = mutableListOf<Video.Server>()
 
-            doc.select("div.options-left a.option").forEach { element ->
-                val name = element.text().trim()
-                val url = element.attr("href")
-
+            doc.select(
+                "div.options-left a.option, .options a.option, a.option, .server-list a, " +
+                    "ul.Options li a, .player-options a, a[href*=player], iframe[src], iframe[data-src]"
+            ).forEach { element ->
+                val name = element.text().trim().ifBlank {
+                    element.attr("title").ifBlank { "Opción" }
+                }
+                val url = element.attr("href").ifBlank {
+                    element.attr("data-src").ifBlank { element.attr("src") }
+                }
                 if (url.isNotEmpty()) {
-                    val absoluteUrl = if (url.startsWith("http")) url else "${TvLibrefutbolProvider.baseUrl}/$url"
-                    servers.add(Video.Server(id = absoluteUrl, name = name))
+                    val absoluteUrl = when {
+                        url.startsWith("http") -> url
+                        url.startsWith("//") -> "https:$url"
+                        else -> "${TvLibrefutbolProvider.baseUrl}/${url.trimStart('/')}"
+                    }
+                    servers.add(Video.Server(id = absoluteUrl, name = name, src = absoluteUrl))
                 }
             }
 
             servers.distinctBy { it.id }.ifEmpty {
-                listOf(Video.Server(id = id, name = "Opción 1"))
+                listOf(Video.Server(id = id, name = "Opción 1", src = id))
             }
         } catch (e: Exception) {
-            listOf(Video.Server(id = id, name = "Opción 1"))
+            listOf(Video.Server(id = id, name = "Opción 1", src = id))
         }
     }
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/TvporinternetHDProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/TvporinternetHDProvider.kt
@@ -1,5 +1,10 @@
 package com.dskja.betterstreamflix.providers
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.util.Log
 import com.dskja.betterstreamflix.adapters.AppAdapter
 import com.dskja.betterstreamflix.models.*
@@ -17,10 +22,17 @@ import java.net.ServerSocket
 import java.net.Socket
 import java.net.URLDecoder
 
-object TvporinternetHDProvider : IptvProvider {
+object TvporinternetHDProvider : IptvProvider, ProviderConfigUrl {
     override val name = "TvPorInternet2"
-    override val baseUrl = "https://www.tvporinternet2.com"
-    override val logo = "https://www.tvporinternet2.com/imge/favicon.png"
+    override val defaultBaseUrl = "https://www.tvporinternet.org"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
+    override val logo = "https://www.tvporinternet.org/imge/favicon.png"
     override val language = "es"
 
     private const val TAG = "TvPorInternet2Spy"
@@ -153,7 +165,7 @@ object TvporinternetHDProvider : IptvProvider {
             val data = script.data()
             if (data.contains("showChannels")) {
                 // Buscar todos los bloques HTML dentro del template string
-                val channelPattern = Regex("""<a href="(https://www\.tvporinternet2\.com/[^"]+\.php)"[^>]*>\s*<div class="live">.*?</div>\s*<img src="([^"]+)"[^>]*>\s*<p>([^<]+)</p>\s*</a>""", RegexOption.DOT_MATCHES_ALL)
+                val channelPattern = Regex("""<a href="(https://www\.tvporinternet(?:2)?\.(?:com|org)/[^"]+\.php)"[^>]*>\s*<div class="live">.*?</div>\s*<img src="([^"]+)"[^>]*>\s*<p>([^<]+)</p>\s*</a>""", RegexOption.DOT_MATCHES_ALL)
 
                 channelPattern.findAll(data).forEach { match ->
                     val link = match.groupValues[1]
@@ -394,21 +406,32 @@ object TvporinternetHDProvider : IptvProvider {
             val doc = fetchDocument(id) ?: throw Exception("No se pudo cargar")
             val servers = mutableListOf<Video.Server>()
 
-            doc.select("div.options-left a.option").forEach { element ->
-                val name = element.text().trim()
-                val url = element.attr("href")
-
+            doc.select(
+                "div.options-left a.option, .options a.option, a.option, .server-list a, " +
+                    "ul.Options li a, .player-options a, a[href*=player], iframe[src], iframe[data-src]"
+            ).forEach { element ->
+                val name = element.text().trim().ifBlank {
+                    element.attr("title").ifBlank { "Opción" }
+                }
+                val url = element.attr("href").ifBlank {
+                    element.attr("data-src").ifBlank { element.attr("src") }
+                }
                 if (url.isNotEmpty()) {
-                    val absoluteUrl = if (url.startsWith("http")) url else "$baseUrl/$url"
-                    servers.add(Video.Server(id = absoluteUrl, name = name))
+                    val absoluteUrl = when {
+                        url.startsWith("http") -> url
+                        url.startsWith("//") -> "https:$url"
+                        else -> "$baseUrl/${url.trimStart('/')}"
+                    }
+                    servers.add(Video.Server(id = absoluteUrl, name = name, src = absoluteUrl))
                 }
             }
 
             servers.distinctBy { it.id }.ifEmpty {
-                listOf(Video.Server(id = id, name = "Opción 1"))
+                listOf(Video.Server(id = id, name = "Opción 1", src = id))
             }
         } catch (e: Exception) {
-            listOf(Video.Server(id = id, name = "Opción 1"))
+            Log.e(TAG, "getServers failed: ${e.message}")
+            listOf(Video.Server(id = id, name = "Opción 1", src = id))
         }
     }
 
@@ -417,18 +440,29 @@ object TvporinternetHDProvider : IptvProvider {
             stopLocalServer()
 
             val coreDoc = fetchDocument(server.id) ?: return@withContext Video("")
-            val playerFrameUrl = coreDoc.selectFirst("iframe#player-frame")?.attr("src") ?: ""
+            val playerFrameUrl = coreDoc.selectFirst(
+                "iframe#player-frame, iframe.player-frame, #player iframe, .player iframe, iframe[src]"
+            )?.attr("src")
+                ?.ifBlank { coreDoc.selectFirst("iframe[data-src]")?.attr("data-src") }
+                .orEmpty()
 
             if (playerFrameUrl.isEmpty()) {
                 Log.e(TAG, "Servidor offline (sin iframe)")
                 return@withContext Video("")
             }
 
-            val iframeDoc = fetchDocument(playerFrameUrl, server.id) ?: return@withContext Video("")
+            val absoluteFrame = when {
+                playerFrameUrl.startsWith("http") -> playerFrameUrl
+                playerFrameUrl.startsWith("//") -> "https:$playerFrameUrl"
+                else -> "$baseUrl/${playerFrameUrl.trimStart('/')}"
+            }
+
+            val iframeDoc = fetchDocument(absoluteFrame, server.id) ?: return@withContext Video("")
             val iframeHtml = iframeDoc.html()
 
             val playlistRegex = """["'](https:[^"']+playlist\.php[^"']+)["']""".toRegex()
             val playlistMatch = playlistRegex.find(iframeHtml)
+                ?: """["'](https:[^"']+\.m3u8[^"']*)["']""".toRegex().find(iframeHtml)
 
             if (playlistMatch != null) {
                 val playlistUrl = playlistMatch.groupValues[1].replace("\\/", "/")

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/VavooProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/VavooProvider.kt
@@ -253,7 +253,20 @@ class VavooProvider(override val language: String) : IptvProvider {
         if (cached != null && (now - (cacheTimestamps[group] ?: 0)) < CACHE_DURATION) {
             return cached
         }
-        val (channels, _) = fetchChannels("", group)
+
+        // Paginate the catalog so Poland/other large groups are not truncated to the first page.
+        val all = linkedMapOf<String, VavooChannel>()
+        var cursor: Int? = null
+        var pages = 0
+        while (pages < 20) {
+            val (pageChannels, nextCursor) = fetchChannels("", group, cursor)
+            if (pageChannels.isEmpty()) break
+            pageChannels.forEach { all[it.id] = it }
+            pages++
+            cursor = nextCursor ?: break
+        }
+
+        val channels = all.values.toList()
         if (channels.isNotEmpty()) {
             homeCache[group] = channels
             cacheTimestamps[group] = now

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/ZaluknijProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/ZaluknijProvider.kt
@@ -1,5 +1,7 @@
 package com.dskja.betterstreamflix.providers
 
+import com.dskja.betterstreamflix.utils.UserPreferences
+
 import android.content.Context
 import android.util.Base64
 import android.util.Log
@@ -22,7 +24,6 @@ import com.dskja.betterstreamflix.utils.ArtworkRequestHeaders
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import okhttp3.Request
 import org.json.JSONObject
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -33,15 +34,26 @@ import retrofit2.http.Url
 import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 
-object ZaluknijProvider : Provider {
+object ZaluknijProvider : Provider, ProviderConfigUrl {
 
     override val name = "Zaluknij"
-    override val baseUrl = "https://zaluknij.cc"
+    // zaluknij.cc is Cloudflare-blocked (error 1005) from many networks; zaluknij.pl is the live dooplay mirror.
+    override val defaultBaseUrl = "https://zaluknij.pl"
+    override val baseUrl: String
+        get() = UserPreferences.getProviderCache(this, UserPreferences.PROVIDER_URL).ifBlank { defaultBaseUrl }
+    override val changeUrlMutex = Mutex()
+
+    override suspend fun onChangeUrl(forceRefresh: Boolean): String = changeUrlMutex.withLock {
+        baseUrl
+    }
     override val logo: String
-        get() = artworkUrl("$baseUrl/public/dist/images/favicon.png") ?: "$baseUrl/public/dist/images/favicon.png"
+        get() = artworkUrl("$baseUrl/wp-content/uploads/2022/03/zaluknij.png")
+            ?: "$baseUrl/wp-content/uploads/2022/03/zaluknij.png"
     override val language = "pl"
 
     private const val TAG = "ZaluknijProvider"
+    private const val BROWSER_UA =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
 
     private var webViewResolver: WebViewResolver? = null
     private val providerMutex = Mutex()
@@ -52,23 +64,28 @@ object ZaluknijProvider : Provider {
     }
 
     private val service = Retrofit.Builder()
-        .baseUrl("$baseUrl/")
+        .baseUrl("$defaultBaseUrl/")
         .client(
             NetworkClient.default.newBuilder()
-                .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS)
+                .connectTimeout(20, TimeUnit.SECONDS)
+                .readTimeout(20, TimeUnit.SECONDS)
+                .callTimeout(40, TimeUnit.SECONDS)
                 .addInterceptor { chain ->
-                    val request = chain.request()
-                    val cookieHeader = clearanceCookieHeader(request.url.toString())
-                    if (cookieHeader.isNullOrBlank() || request.header("Cookie") != null) {
-                        chain.proceed(request)
-                    } else {
-                        chain.proceed(
-                            request.newBuilder()
-                                .header("Cookie", cookieHeader)
-                                .build()
-                        )
+                    val original = chain.request()
+                    val cookieHeader = clearanceCookieHeader(original.url.toString())
+                    val builder = original.newBuilder()
+                        .header("User-Agent", BROWSER_UA)
+                        .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
+                        .header("Accept-Language", "pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7")
+                        .header("Referer", "$baseUrl/")
+                        .header("Origin", baseUrl.trimEnd('/'))
+                        .header("Sec-Fetch-Dest", "document")
+                        .header("Sec-Fetch-Mode", "navigate")
+                        .header("Sec-Fetch-Site", "same-origin")
+                    if (!cookieHeader.isNullOrBlank() && original.header("Cookie") == null) {
+                        builder.header("Cookie", cookieHeader)
                     }
+                    chain.proceed(builder.build())
                 }
                 .build()
         )
@@ -90,13 +107,18 @@ object ZaluknijProvider : Provider {
         val document = getDocument(baseUrl)
         val categories = mutableListOf<Category>()
 
-        document.select("h3.section-title").forEach { header ->
-            val title = header.text().trim().orEmpty()
-            val content = nextContentBlock(header) ?: return@forEach
-            val items = parseHomeItems(header, content).take(20)
+        document.select("div.module").forEach { module ->
+            val title = module.selectFirst("header h2, header h1, h2")?.text()?.trim().orEmpty()
+            if (title.isBlank()) return@forEach
+            val items = parseTiles(module).take(20)
             if (items.isNotEmpty()) {
                 categories.add(Category(title, items))
             }
+        }
+
+        if (categories.isEmpty()) {
+            val movies = parseTiles(document).filterIsInstance<Movie>().take(20)
+            if (movies.isNotEmpty()) categories.add(Category("FILMY ONLINE", movies))
         }
 
         return categories
@@ -106,42 +128,25 @@ object ZaluknijProvider : Provider {
         if (query.isBlank()) {
             return listOf(
                 Genre(id = "/filmy-online/", name = "Filmy"),
-                Genre(id = "/seriale-online/index", name = "Seriale"),
+                Genre(id = "/seriale-online/", name = "Seriale"),
             )
         }
 
         val url = buildString {
-            append("$baseUrl/wyszukiwarka?phrase=${encodeQuery(query)}")
-            if (page > 1) {
-                append("&page=$page")
-            }
+            append("$baseUrl/?s=${encodeQuery(query)}")
+            if (page > 1) append("&page=$page")
         }
-
         return parseSearchResults(getDocument(url)).distinctBy(::itemKey)
     }
 
     override suspend fun getMovies(page: Int): List<Movie> {
-        val url = if (page <= 1) {
-            "$baseUrl/filmy-online/"
-        } else {
-            "$baseUrl/filmy-online/?page=$page"
-        }
-
-        return parseTiles(getDocument(url))
-            .filterIsInstance<Movie>()
-            .distinctBy { it.id }
+        val url = if (page <= 1) "$baseUrl/filmy-online/" else "$baseUrl/filmy-online/page/$page/"
+        return parseTiles(getDocument(url)).filterIsInstance<Movie>().distinctBy { it.id }
     }
 
     override suspend fun getTvShows(page: Int): List<TvShow> {
-        val url = if (page <= 1) {
-            "$baseUrl/seriale-online/index"
-        } else {
-            "$baseUrl/seriale-online/index?url=seriale-online%2Findex&page=$page"
-        }
-
-        return parseTiles(getDocument(url))
-            .filterIsInstance<TvShow>()
-            .distinctBy { it.id }
+        val url = if (page <= 1) "$baseUrl/seriale-online/" else "$baseUrl/seriale-online/page/$page/"
+        return parseTiles(getDocument(url)).filterIsInstance<TvShow>().distinctBy { it.id }
     }
 
     override suspend fun getMovie(id: String): Movie {
@@ -150,19 +155,8 @@ object ZaluknijProvider : Provider {
     }
 
     override suspend fun getTvShow(id: String): TvShow {
-        val initialUrl = toAbsoluteUrl(id)
-        var document = getDocument(initialUrl)
-        val detailUrl = document.selectFirst("#single-poster a[href*=\"/serial-online/\"]")
-            ?.attr("href")
-            ?.takeIf { !it.contains("/odcinek-") }
-            ?.let(::toAbsoluteUrl)
-            ?: initialUrl
-
-        if (detailUrl != initialUrl) {
-            document = getDocument(detailUrl)
-        }
-
-        return parseTvShow(document, detailUrl)
+        val url = toAbsoluteUrl(id)
+        return parseTvShow(getDocument(url), url)
     }
 
     override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
@@ -178,29 +172,21 @@ object ZaluknijProvider : Provider {
 
     override suspend fun getGenre(id: String, page: Int): Genre {
         return when {
-            id.startsWith("/filmy-online") -> Genre(
-                id = id,
-                name = "Filmy",
-                shows = getMovies(page).map { it as Show },
-            )
-
-            id.startsWith("/seriale-online") -> Genre(
-                id = id,
-                name = "Seriale",
-                shows = getTvShows(page).map { it as Show },
-            )
-
+            id.contains("filmy-online") -> Genre(id = id, name = "Filmy", shows = getMovies(page).map { it as Show })
+            id.contains("seriale-online") -> Genre(id = id, name = "Seriale", shows = getTvShows(page).map { it as Show })
             else -> {
                 val url = when {
                     id.startsWith("http") -> id
                     id.startsWith("/") -> "$baseUrl$id"
                     else -> "$baseUrl/$id"
                 }
-                val finalUrl = if (page > 1 && !url.contains("?")) "$url?page=$page" else url
+                val finalUrl = if (page > 1 && !url.contains("page/")) {
+                    url.trimEnd('/') + "/page/$page/"
+                } else url
                 val document = getDocument(finalUrl)
                 Genre(
                     id = id,
-                    name = document.selectFirst(".section-header .headline-gradient")?.text()?.trim()
+                    name = document.selectFirst("h1, .section-header .headline-gradient")?.text()?.trim()
                         ?: document.title().substringBefore(" - ").trim().ifBlank { id },
                     shows = parseTiles(document).filterIsInstance<Show>(),
                 )
@@ -209,228 +195,150 @@ object ZaluknijProvider : Provider {
     }
 
     override suspend fun getPeople(id: String, page: Int): People {
-        return People(
-            id = id,
-            name = id,
-            filmography = emptyList(),
-        )
+        return People(id = id, name = id, filmography = emptyList())
     }
 
     override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
         val document = getDocument(toAbsoluteUrl(id))
-        return document.select("div#link-list tbody tr").mapNotNull { row ->
-            val link = row.selectFirst("a[href]") ?: return@mapNotNull null
-            val href = link.absUrl("href").ifBlank { link.attr("href") }
-            if (href.isBlank()) return@mapNotNull null
+        val servers = mutableListOf<Video.Server>()
 
-            val cells = row.select("td")
-            val host = link.selectFirst("img")?.attr("alt")
-                .blankToNull()
-                ?: link.text().trim()
-            val version = cells.getOrNull(2)?.text()?.trim().orEmpty()
-            val quality = cells.getOrNull(3)?.text()?.trim().orEmpty()
-            val serverName = buildString {
-                append(host.ifBlank { "Server" })
-                if (version.isNotBlank()) append(" [$version]")
-                if (quality.isNotBlank()) append(" [$quality]")
-            }
-
-            Video.Server(
-                id = href,
-                name = serverName,
-                src = decodeIframeSrc(link.attr("data-iframe")).ifBlank { href },
+        // Dooplay player options (skip trailers)
+        document.select("li.dooplay_player_option, ul#playeroptionsul li").forEach { option ->
+            val nume = option.attr("data-nume")
+            if (nume.equals("trailer", ignoreCase = true)) return@forEach
+            val post = option.attr("data-post")
+            val type = option.attr("data-type").ifBlank { "movie" }
+            val title = option.selectFirst(".title")?.text()?.trim().orEmpty().ifBlank { "Server" }
+            if (post.isBlank() || nume.isBlank()) return@forEach
+            servers += Video.Server(
+                id = "dooplay|$post|$type|$nume",
+                name = title,
+                src = toAbsoluteUrl(id),
             )
-        }.distinctBy { it.id }
+        }
+
+        // Direct non-intro video sources
+        document.select("video source[src], #player-frame source[src], video#video1 source[src]").forEach { source ->
+            val src = source.attr("abs:src").ifBlank { source.attr("src") }
+            if (src.isBlank()) return@forEach
+            if (src.contains("/intro", ignoreCase = true) || src.contains("intro2.mp4", ignoreCase = true)) {
+                return@forEach
+            }
+            val label = source.attr("label").ifBlank { "Direct" }
+            servers += Video.Server(id = src, name = label, src = src)
+        }
+
+        // Legacy zaluknij.cc iframe table
+        document.select("div#link-list tbody tr").forEach { row ->
+            val link = row.selectFirst("a[href]") ?: return@forEach
+            val href = link.absUrl("href").ifBlank { link.attr("href") }
+            if (href.isBlank()) return@forEach
+            val host = link.selectFirst("img")?.attr("alt").blankToNull() ?: link.text().trim()
+            val iframe = decodeIframeSrc(link.attr("data-iframe")).ifBlank { href }
+            servers += Video.Server(id = href, name = host.ifBlank { "Server" }, src = iframe)
+        }
+
+        if (servers.isEmpty() &&
+            (document.html().contains("require_login", ignoreCase = true) ||
+                document.selectFirst("#lock-info") != null)
+        ) {
+            throw Exception("Zaluknij wymaga zalogowania, aby odtworzyć ten tytuł")
+        }
+
+        return servers.distinctBy { it.id }
     }
 
     override suspend fun getVideo(server: Video.Server): Video {
-        return Extractor.extract(server.src.ifBlank { server.id }, server)
+        if (server.id.startsWith("dooplay|")) {
+            val parts = server.id.split("|")
+            val post = parts.getOrNull(1).orEmpty()
+            val type = parts.getOrNull(2).orEmpty()
+            val nume = parts.getOrNull(3).orEmpty()
+            val ajaxUrl = "$baseUrl/wp-admin/admin-ajax.php?action=doo_player_ajax&post=$post&nume=$nume&type=$type"
+            val document = getDocument(ajaxUrl)
+            val embed = document.selectFirst("iframe[src], iframe[data-src]")
+                ?.let { it.attr("abs:src").ifBlank { it.attr("src") }.ifBlank { it.attr("data-src") } }
+                ?: Regex("""src=["']([^"']+)["']""").find(document.html())?.groupValues?.getOrNull(1)
+                ?: throw Exception("Zaluknij player option returned no embed")
+            val absolute = when {
+                embed.startsWith("//") -> "https:$embed"
+                embed.startsWith("http") -> embed
+                else -> toAbsoluteUrl(embed)
+            }
+            return Extractor.extract(absolute, server)
+        }
+
+        val src = server.src.ifBlank { server.id }
+        if (src.contains(".mp4", ignoreCase = true) || src.contains(".m3u8", ignoreCase = true)) {
+            return Video(
+                source = src,
+                headers = mapOf(
+                    "User-Agent" to BROWSER_UA,
+                    "Referer" to "$baseUrl/",
+                )
+            )
+        }
+        return Extractor.extract(src, server)
     }
 
     private fun parseTiles(container: Element): List<AppAdapter.Item> {
-        return container.select("div.tile > a[href]").mapNotNull { anchor ->
+        return container.select("article.item, .items article, div.item").mapNotNull { article ->
+            val anchor = article.selectFirst("a[href]") ?: return@mapNotNull null
             val href = anchor.absUrl("href").ifBlank { anchor.attr("href") }
             if (href.isBlank()) return@mapNotNull null
 
-            val image = anchor.selectFirst("img")
-            val title = image?.attr("alt")
+            val image = article.selectFirst("img")
+            val title = article.selectFirst(".data h3 a, .data h3, h3 a, h3, .title")?.text()?.trim()
                 .blankToNull()
+                ?: image?.attr("alt").blankToNull()
                 ?: anchor.attr("title").blankToNull()
-                ?: anchor.selectFirst(".info-bar .title")?.ownText().blankToNull()
-                ?: anchor.text().trim()
-
+                ?: return@mapNotNull null
             val poster = artworkUrl(
-                image?.attr("src").blankToNull()
-                    ?: image?.attr("data-src").blankToNull(),
+                image?.attr("src").blankToNull() ?: image?.attr("data-src").blankToNull(),
                 referer = baseUrl
             )
-            val year = anchor.selectFirst(".year")?.text()?.extractYear()
+            val year = article.selectFirst(".data span, .year")?.text()?.extractYear()
 
             when {
-                href.contains("/film/") -> Movie(
-                    id = href,
-                    title = title,
-                    released = year,
-                    poster = poster,
-                    banner = poster,
-                )
-
-                href.contains("/serial-online/") -> TvShow(
-                    id = href,
-                    title = title,
-                    poster = poster,
-                    banner = poster,
-                )
-
+                href.contains("/filmy-online/") || article.hasClass("movies") || article.className().contains("movies") ->
+                    Movie(id = href, title = title, released = year, poster = poster, banner = poster)
+                href.contains("/seriale-online/") || article.hasClass("tvshows") || article.className().contains("tvshows") ->
+                    TvShow(id = href, title = title, poster = poster, banner = poster)
+                href.contains("/film/") ->
+                    Movie(id = href, title = title, released = year, poster = poster, banner = poster)
+                href.contains("/serial-online/") ->
+                    TvShow(id = href, title = title, poster = poster, banner = poster)
                 else -> null
             }
-        }.distinctBy(::itemKey)
-    }
-
-    private fun parseHomeItems(header: Element, container: Element): List<AppAdapter.Item> {
-        return when {
-            header.text().contains("Ostatnio dodane odcinki", ignoreCase = true) ||
-                container.classNames().any { it.contains("episode", ignoreCase = true) } -> {
-                parseHomeEpisodes(container)
-            }
-
-            else -> parseHomeMovies(container)
-        }
-    }
-
-    private fun parseHomeMovies(container: Element): List<AppAdapter.Item> {
-        return container.select("a[href]").mapNotNull { anchor ->
-            val href = anchor.absUrl("href").ifBlank { anchor.attr("href") }
-            if (!href.contains("/film/")) return@mapNotNull null
-
-            val image = anchor.selectFirst("img")
-            val poster = artworkUrl(
-                image?.attr("src").blankToNull()
-                    ?: image?.attr("data-src").blankToNull(),
-                referer = baseUrl
-            )
-            val title = image?.attr("alt")
-                .blankToNull()
-                ?: anchor.attr("title").blankToNull()
-                ?: anchor.selectFirst(".title")?.text()?.trim().blankToNull()
-                ?: anchor.text().trim()
-            val year = anchor.selectFirst(".year")?.text()?.extractYear()
-
-            Movie(
-                id = href,
-                title = title,
-                released = year,
-                poster = poster,
-                banner = poster,
-            )
         }.distinctBy(::itemKey)
     }
 
     private fun parseSearchResults(document: Document): List<AppAdapter.Item> {
-        return document.select("#advanced-search a.item[href]").mapNotNull { anchor ->
+        val fromResultItems = document.select(".result-item article, .search-page .result-item").mapNotNull { article ->
+            val anchor = article.selectFirst("a[href]") ?: return@mapNotNull null
             val href = anchor.absUrl("href").ifBlank { anchor.attr("href") }
-            if (href.isBlank()) return@mapNotNull null
-
-            val image = anchor.selectFirst("img")
-            val poster = artworkUrl(
-                image?.attr("src").blankToNull()
-                    ?: image?.attr("data-src").blankToNull(),
-                referer = baseUrl
-            )
-            val title = image?.attr("alt")
-                .blankToNull()
-                ?: anchor.attr("title").blankToNull()
-                ?: anchor.selectFirst(".title")?.text()?.trim().blankToNull()
-                ?: anchor.text().trim()
-            val overview = anchor.selectFirst(".description")?.text()?.trim().blankToNull()
-            val year = anchor.attr("title").extractYear()
-
+            val title = article.selectFirst(".title a, .title, h3")?.text()?.trim().orEmpty()
+            val poster = artworkUrl(article.selectFirst("img")?.attr("src"), referer = baseUrl)
             when {
-                href.contains("/film/") -> Movie(
-                    id = href,
-                    title = title,
-                    overview = overview,
-                    released = year,
-                    poster = poster,
-                    banner = poster,
-                )
-
-                href.contains("/serial-online/") -> TvShow(
-                    id = href,
-                    title = title,
-                    overview = overview,
-                    poster = poster,
-                    banner = poster,
-                )
-
+                href.contains("/filmy-online/") || href.contains("/film/") ->
+                    Movie(id = href, title = title, poster = poster, banner = poster)
+                href.contains("/seriale-online/") || href.contains("/serial-online/") ->
+                    TvShow(id = href, title = title, poster = poster, banner = poster)
                 else -> null
             }
-        }.distinctBy(::itemKey)
-    }
-
-    private fun parseHomeEpisodes(container: Element): List<AppAdapter.Item> {
-        return container.select("a.list-group-item[href*=\"/serial-online/\"]").mapNotNull { anchor ->
-            val href = anchor.absUrl("href").ifBlank { anchor.attr("href") }
-            if (href.isBlank()) return@mapNotNull null
-
-            val epCode = anchor.selectFirst(".ep-code")?.text().orEmpty()
-            val episodeNumber = epCode.extractEpisodeNumber() ?: href.extractEpisodeNumberFromUrl()
-                ?: return@mapNotNull null
-            val seasonNumber = epCode.extractSeasonNumber() ?: 1
-            val showId = href.substringBeforeLast("/").substringBeforeLast("/")
-            val title = anchor.selectFirst(".ep-title")?.text()?.trim()
-                ?: anchor.attr("title").blankToNull()
-                ?: anchor.text().trim()
-            val badge = anchor.selectFirst(".badge")?.text()?.trim()
-            val poster = anchor.selectFirst("img")?.let { image ->
-                artworkUrl(
-                    image.attr("src").blankToNull()
-                        ?: image.attr("data-src").blankToNull(),
-                    referer = baseUrl
-                )
-            }
-
-            TvShow(
-                id = href,
-                title = title,
-                overview = badge,
-                poster = poster,
-                banner = poster,
-                seasons = listOf(
-                    Season(
-                        id = showId,
-                        number = seasonNumber,
-                        title = "Sezon $seasonNumber",
-                        poster = poster,
-                        episodes = listOf(
-                            Episode(
-                                id = href,
-                                number = episodeNumber,
-                                title = title,
-                                overview = badge,
-                                poster = poster,
-                            )
-                        )
-                    )
-                ),
-            )
-        }.distinctBy(::itemKey)
+        }
+        return (fromResultItems + parseTiles(document)).distinctBy(::itemKey)
     }
 
     private fun parseMovie(document: Document, id: String): Movie {
-        val title = document.selectFirst("h1")?.text()?.trim()
+        val title = document.selectFirst("h1, .sheader .data h1")?.text()?.trim()
             ?: document.title().substringBefore(" - ").trim()
         val poster = artworkUrl(
             document.selectFirst("meta[property=og:image]")?.attr("content").blankToNull()
-                ?: document.selectFirst("#single-poster img")?.attr("src").blankToNull(),
+                ?: document.selectFirst(".poster img, #single-poster img")?.attr("src").blankToNull(),
             referer = id
         )
-        val description = document.selectFirst("p.description")?.text()?.trim()
-        val overview = description
-            ?.substringAfter(" - ")
-            ?.trim()
-            ?.ifBlank { description }
-
+        val overview = document.selectFirst(".wp-content p, .description, p.description")?.text()?.trim()
         return Movie(
             id = id,
             title = title,
@@ -442,17 +350,47 @@ object ZaluknijProvider : Provider {
     }
 
     private fun parseTvShow(document: Document, id: String): TvShow {
-        val title = document.selectFirst("h1")?.text()?.trim()
-            ?: document.selectFirst("h2")?.text()?.trim()
+        val title = document.selectFirst("h1, .sheader .data h1")?.text()?.trim()
             ?: document.title().substringBefore(" - ").trim()
         val poster = artworkUrl(
             document.selectFirst("meta[property=og:image]")?.attr("content").blankToNull()
-                ?: document.selectFirst("#single-poster img")?.attr("src").blankToNull(),
+                ?: document.selectFirst(".poster img, #single-poster img")?.attr("src").blankToNull(),
             referer = id
         )
-        val overview = document.selectFirst("p.description")?.text()?.trim()?.ifBlank { null }
-        val seasons = document.select("ul#episode-list > li").mapNotNull { seasonElement ->
-            parseSeason(seasonElement, id, poster)
+        val overview = document.selectFirst(".wp-content p, .description, p.description")?.text()?.trim()
+
+        val seasons = document.select("#seasons .se-c, .seasons .se-c, ul#episode-list > li").mapNotNull { seasonElement ->
+            if (seasonElement.hasClass("se-c") || seasonElement.className().contains("se-c")) {
+                val seasonNumber = seasonElement.selectFirst(".se-t")?.text()?.trim()?.toIntOrNull()
+                    ?: seasonElement.selectFirst("> span")?.text()?.extractSeasonNumber()
+                    ?: return@mapNotNull null
+                val episodes = seasonElement.select("ul.episodios li, ul > li").mapNotNull { li ->
+                    val anchor = li.selectFirst("a[href]") ?: return@mapNotNull null
+                    val href = anchor.absUrl("href").ifBlank { anchor.attr("href") }
+                    if (href.isBlank()) return@mapNotNull null
+                    val numerando = li.selectFirst(".numerando")?.text()?.trim().orEmpty()
+                    val episodeNumber = numerando.substringAfter("-").trim().toIntOrNull()
+                        ?: anchor.text().extractEpisodeNumber()
+                        ?: href.extractEpisodeNumberFromUrl()
+                        ?: return@mapNotNull null
+                    Episode(
+                        id = href,
+                        number = episodeNumber,
+                        title = li.selectFirst(".episodiotitle a, .episodiotitle")?.text()?.trim()
+                            ?: anchor.text().trim().ifBlank { "Odcinek $episodeNumber" },
+                        poster = poster,
+                    )
+                }.sortedBy { it.number }
+                Season(
+                    id = "$id|$seasonNumber",
+                    number = seasonNumber,
+                    title = "Sezon $seasonNumber",
+                    poster = poster,
+                    episodes = episodes,
+                )
+            } else {
+                parseLegacySeason(seasonElement, id, poster)
+            }
         }.sortedBy { it.number }
 
         return TvShow(
@@ -465,13 +403,20 @@ object ZaluknijProvider : Provider {
         )
     }
 
-    private fun parseSeason(seasonElement: Element, showUrl: String, poster: String?): Season? {
+    private fun parseLegacySeason(seasonElement: Element, showUrl: String, poster: String?): Season? {
         val seasonLabel = seasonElement.selectFirst("> span")?.text()?.trim().orEmpty()
         val seasonNumber = seasonLabel.extractSeasonNumber() ?: return null
         val episodes = seasonElement.select("ul > li > a[href*=\"/odcinek-\"]").mapNotNull { anchor ->
-            parseEpisode(anchor, poster)
+            val href = anchor.absUrl("href").ifBlank { anchor.attr("href") }
+            if (href.isBlank()) return@mapNotNull null
+            val episodeNumber = anchor.text().extractEpisodeNumber() ?: return@mapNotNull null
+            Episode(
+                id = href,
+                number = episodeNumber,
+                title = anchor.text().substringAfter("] ").trim().ifBlank { "Odcinek $episodeNumber" },
+                poster = poster,
+            )
         }.sortedBy { it.number }
-
         return Season(
             id = "$showUrl|$seasonNumber",
             number = seasonNumber,
@@ -481,24 +426,8 @@ object ZaluknijProvider : Provider {
         )
     }
 
-    private fun parseEpisode(anchor: Element, poster: String?): Episode? {
-        val href = anchor.absUrl("href").ifBlank { anchor.attr("href") }
-        if (href.isBlank()) return null
-
-        val episodeNumber = anchor.text().extractEpisodeNumber() ?: return null
-        val title = anchor.text().substringAfter("] ").trim().ifBlank { "Odcinek $episodeNumber" }
-
-        return Episode(
-            id = href,
-            number = episodeNumber,
-            title = title,
-            poster = poster,
-        )
-    }
-
     private fun decodeIframeSrc(encoded: String): String {
         if (encoded.isBlank()) return ""
-
         return try {
             val decoded = String(Base64.decode(encoded, Base64.DEFAULT), Charsets.UTF_8).trim()
             JSONObject(decoded).optString("src").ifBlank {
@@ -507,15 +436,6 @@ object ZaluknijProvider : Provider {
         } catch (_: Exception) {
             ""
         }
-    }
-
-    private fun nextContentBlock(header: Element): Element? {
-        var sibling = header.nextElementSibling()
-        while (sibling != null) {
-            if (sibling.hasClass("row") || sibling.hasClass("list-group")) return sibling
-            sibling = sibling.nextElementSibling()
-        }
-        return null
     }
 
     private fun itemKey(item: AppAdapter.Item): String {
@@ -527,42 +447,23 @@ object ZaluknijProvider : Provider {
         }
     }
 
-    private fun String.extractYear(): String? {
-        return Regex("""\b(19|20)\d{2}\b""").find(this)?.value
-    }
+    private fun String.extractYear(): String? = Regex("""\b(19|20)\d{2}\b""").find(this)?.value
 
-    private fun String.extractSeasonNumber(): Int? {
-        return Regex("""\b(?:Sezon|S)\s*0*(\d+)\b""", RegexOption.IGNORE_CASE)
-            .find(this)
-            ?.groupValues
-            ?.getOrNull(1)
-            ?.toIntOrNull()
-    }
+    private fun String.extractSeasonNumber(): Int? =
+        Regex("""\b(?:Sezon|S)\s*0*(\d+)\b""", RegexOption.IGNORE_CASE)
+            .find(this)?.groupValues?.getOrNull(1)?.toIntOrNull()
 
-    private fun String.extractEpisodeNumber(): Int? {
-        return Regex("""\b(?:Odcinek|E)\s*0*(\d+)\b""", RegexOption.IGNORE_CASE)
-            .find(this)
-            ?.groupValues
-            ?.getOrNull(1)
-            ?.toIntOrNull()
+    private fun String.extractEpisodeNumber(): Int? =
+        Regex("""\b(?:Odcinek|E)\s*0*(\d+)\b""", RegexOption.IGNORE_CASE)
+            .find(this)?.groupValues?.getOrNull(1)?.toIntOrNull()
             ?: Regex("""e0*(\d+)\b""", RegexOption.IGNORE_CASE)
-                .find(this)
-                ?.groupValues
-                ?.getOrNull(1)
-                ?.toIntOrNull()
-    }
+                .find(this)?.groupValues?.getOrNull(1)?.toIntOrNull()
 
-    private fun String.extractEpisodeNumberFromUrl(): Int? {
-        return Regex("""/odcinek-(\d+)""", RegexOption.IGNORE_CASE)
-            .find(this)
-            ?.groupValues
-            ?.getOrNull(1)
-            ?.toIntOrNull()
-    }
+    private fun String.extractEpisodeNumberFromUrl(): Int? =
+        Regex("""(?:/odcinek-|s\d+e)(\d+)""", RegexOption.IGNORE_CASE)
+            .find(this)?.groupValues?.getOrNull(1)?.toIntOrNull()
 
-    private fun String?.blankToNull(): String? {
-        return this?.trim()?.takeIf { it.isNotBlank() }
-    }
+    private fun String?.blankToNull(): String? = this?.trim()?.takeIf { it.isNotBlank() }
 
     private suspend fun getDocument(url: String): Document {
         return try {
@@ -571,19 +472,18 @@ object ZaluknijProvider : Provider {
             if (requiresClearance(html)) {
                 throw IllegalStateException("Cloudflare clearance required")
             }
+            if (html.contains("error code: 1005", ignoreCase = true)) {
+                throw Exception("Zaluknij zablokował to połączenie (Cloudflare 1005). Spróbuj zmienić URL dostawcy.")
+            }
             document
         } catch (e: HttpException) {
-            if (e.code() != 403 && e.code() != 503) {
-                throw e
-            }
+            if (e.code() != 403 && e.code() != 503) throw e
             Log.d(TAG, "Resolving clearance with WebView for $url: HTTP ${e.code()}")
             val html = providerMutex.withLock { getResolver().get(url) }
             promoteClearanceCookies(url)
             org.jsoup.Jsoup.parse(html).apply { setBaseUri(url) }
         } catch (e: Exception) {
-            if (!looksLikeClearanceFailure(e)) {
-                throw e
-            }
+            if (!looksLikeClearanceFailure(e)) throw e
             Log.d(TAG, "Resolving clearance with WebView for $url: ${e.message}")
             val html = providerMutex.withLock { getResolver().get(url) }
             promoteClearanceCookies(url)
@@ -595,6 +495,8 @@ object ZaluknijProvider : Provider {
         val message = error.message.orEmpty()
         return message.contains("Cloudflare clearance required", ignoreCase = true) ||
             message.contains("Just a moment", ignoreCase = true) ||
+            message.contains("One moment, please", ignoreCase = true) ||
+            message.contains("Proszę czekać", ignoreCase = true) ||
             message.contains("Checking your browser", ignoreCase = true) ||
             message.contains("cf-browser-verification", ignoreCase = true)
     }
@@ -602,62 +504,49 @@ object ZaluknijProvider : Provider {
     private fun requiresClearance(html: String): Boolean {
         return html.contains("cf-browser-verification", ignoreCase = true) ||
             html.contains("Checking your browser", ignoreCase = true) ||
-            html.contains("Just a moment...", ignoreCase = true)
+            html.contains("Just a moment...", ignoreCase = true) ||
+            html.contains("One moment, please", ignoreCase = true) ||
+            html.contains("Proszę czekać", ignoreCase = true) ||
+            // Soft antibot interstitial that auto-reloads every few seconds.
+            (html.contains("window.location.reload()", ignoreCase = true) &&
+                html.contains("spinner", ignoreCase = true) &&
+                !html.contains("dooplay", ignoreCase = true) &&
+                !html.contains("article", ignoreCase = true))
     }
 
     private fun promoteClearanceCookies(sourceUrl: String) {
         val cookieManager = CookieManager.getInstance()
-        val cookieHeader = listOf(
-            sourceUrl,
-            baseUrl,
-            "$baseUrl/"
-        ).firstNotNullOfOrNull { candidate ->
-            cookieManager.getCookie(candidate)?.takeIf { it.isNotBlank() }
-        }.orEmpty()
-
-        if (cookieHeader.isBlank()) {
-            return
-        }
-
-        cookieHeader.split(";")
-            .map { it.trim() }
-            .filter { it.isNotBlank() }
-            .forEach { cookie ->
-                val rootCookie = if (cookie.contains("Path=", ignoreCase = true)) cookie else "$cookie; Path=/"
-                listOf(sourceUrl, baseUrl, "$baseUrl/").distinct().forEach { target ->
-                    cookieManager.setCookie(target, rootCookie)
-                }
+        val cookieHeader = listOf(sourceUrl, baseUrl, "$baseUrl/")
+            .firstNotNullOfOrNull { candidate -> cookieManager.getCookie(candidate)?.takeIf { it.isNotBlank() } }
+            .orEmpty()
+        if (cookieHeader.isBlank()) return
+        cookieHeader.split(";").map { it.trim() }.filter { it.isNotBlank() }.forEach { cookie ->
+            val rootCookie = if (cookie.contains("Path=", ignoreCase = true)) cookie else "$cookie; Path=/"
+            listOf(sourceUrl, baseUrl, "$baseUrl/").distinct().forEach { target ->
+                cookieManager.setCookie(target, rootCookie)
             }
-
+        }
         cookieManager.flush()
     }
 
     private fun clearanceCookieHeader(requestUrl: String): String? {
         val cookieManager = CookieManager.getInstance()
-        return listOf(
-            requestUrl,
-            baseUrl,
-            "$baseUrl/"
-        ).firstNotNullOfOrNull { candidate ->
-            cookieManager.getCookie(candidate)?.takeIf { it.isNotBlank() }
-        }
+        return listOf(requestUrl, baseUrl, "$baseUrl/")
+            .firstNotNullOfOrNull { candidate -> cookieManager.getCookie(candidate)?.takeIf { it.isNotBlank() } }
     }
 
     private fun artworkUrl(url: String?, referer: String = baseUrl): String? {
         val image = url?.trim().orEmpty()
         if (image.isBlank()) return null
-
         return ArtworkRequestHeaders.withHeaders(
             url = image,
             referer = referer,
-            userAgent = NetworkClient.USER_AGENT,
+            userAgent = BROWSER_UA,
             cookie = clearanceCookieHeader(referer),
         )
     }
 
-    private fun encodeQuery(query: String): String {
-        return URLEncoder.encode(query, Charsets.UTF_8.name())
-    }
+    private fun encodeQuery(query: String): String = URLEncoder.encode(query, Charsets.UTF_8.name())
 
     private fun toAbsoluteUrl(url: String): String {
         return when {

--- a/app/src/main/java/com/dskja/betterstreamflix/utils/UserPreferences.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/utils/UserPreferences.kt
@@ -26,7 +26,7 @@ object UserPreferences {
     // Default DoH Provider URL (Cloudflare)
     private const val DEFAULT_DOH_PROVIDER_URL = "https://cloudflare-dns.com/dns-query"
     const val DOH_DISABLED_VALUE = "" // Value to represent DoH being disabled
-    private const val DEFAULT_SERIENSTREAM_DOMAIN = "s.to"
+    private const val DEFAULT_SERIENSTREAM_DOMAIN = "serienstream.to"
     private const val DEFAULT_MOFLIX_DOMAIN = "moflix-stream.xyz"
     private const val DEFAULT_STREAMINGCOMMUNITY_DOMAIN = "streamingunity.cc"
     private const val DEFAULT_CUEVANA_DOMAIN = "cuevana.gs"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -520,4 +520,8 @@
     <string name="settings_refresh_cache_success">Cache erfolgreich aktualisiert</string>
     <string name="supabase_instructions_title">Anleitung</string>
     <string name="supabase_instructions_summary">Die ausführliche Anleitung zur Einrichtung von Supabase-Konto und Synchronisierung im Browser öffnen</string>
+    <string name="player_live_badge">LIVE</string>
+    <string name="player_live_channel">Live-Kanal</string>
+    <string name="settings_tmdb_api_key_missing">TMDb-API-Schlüssel fehlt. Trage ihn in den Einstellungen ein, um den TMDb-Provider zu nutzen.</string>
+    <string name="settings_tmdb_api_key_summary">Erforderlich für den TMDb-Provider. Schlüssel unter themoviedb.org/settings/api erstellen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -541,7 +541,10 @@
 
     <string name="settings_category_tmdb">TMDb Settings</string>
     <string name="settings_tmdb_api_key">Custom TMDb API Key</string>
-    <string name="settings_tmdb_api_key_summary">Leave empty to use the default API key provided with the app</string>
+    <string name="settings_tmdb_api_key_summary">Required for the TMDb provider. Create a key at themoviedb.org/settings/api</string>
+    <string name="settings_tmdb_api_key_missing">TMDb API key is missing. Add it in Settings to use the TMDb provider.</string>
+    <string name="player_live_badge">LIVE</string>
+    <string name="player_live_channel">Live channel</string>
     <string name="settings_tmdb_api_key_success">API Key updated successfully</string>
     <string name="settings_tmdb_api_key_reset">Using default TMDb API Key</string>
 


### PR DESCRIPTION
## Summary
- SerienStream default domain → `serienstream.to` (s.to dead per [serien.domains](https://serien.domains))
- Almost all providers: Settings → change Provider URL (`ProviderConfigUrl`)
- Updated mirrors / parsing for many broken providers (HDFilme, GuardaSerie, Pelisplus, Frembed, CineHax, Zaluknij, Animefenix, Anikoto, Vavoo PL, sports, etc.)
- Live TV player: LIVE badge, skip next-episode flow, ExoPlayer live configuration
- TMDb: clear error when API key is missing

## Notes
- Cloudflare-heavy sites may still need on-device WebView clearance
- Users can override any provider URL in Settings if a domain changes again

## Test plan
- [ ] SerienStream loads on serienstream.to
- [ ] Settings shows Provider URL for current provider and applies after change
- [ ] TMDb without key shows API-key message
- [ ] Pluto/Vavoo player shows LIVE (not S1E1)
- [ ] Spot-check previously broken providers (HDFilme, GuardaSerie, Frembed, CineHax)