### PR TITLE
fix(firetv): Fire Stick 4K 1st gen splash → crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,6 +94,14 @@ android {
         viewBinding true
         buildConfig true
     }
+
+    packaging {
+        jniLibs {
+            // Fire OS 6 / older sticks fail to load compressed in-APK native libs
+            // (Conscrypt, Cronet) → splash then instant exit.
+            useLegacyPackaging = true
+        }
+    }
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,6 +60,7 @@
         android:name=".BetterStreamflixApp"
         android:allowBackup="true"
         android:banner="@mipmap/ic_banner"
+        android:extractNativeLibs="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:logo="@mipmap/ic_launcher"

--- a/app/src/main/java/com/dskja/betterstreamflix/BetterStreamflixApp.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/BetterStreamflixApp.kt
@@ -109,7 +109,9 @@ class BetterStreamflixApp : Application() {
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
-        if (level >= TRIM_MEMORY_RUNNING_LOW) {
+        if (level >= TRIM_MEMORY_RUNNING_LOW &&
+            !DeviceCapabilities.shouldUseConstrainedPlayback(this)
+        ) {
             CacheUtils.clearAppCache(this)
         }
     }

--- a/app/src/main/java/com/dskja/betterstreamflix/BetterStreamflixApp.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/BetterStreamflixApp.kt
@@ -15,6 +15,7 @@ import com.dskja.betterstreamflix.sync.SupabaseProvider
 import com.dskja.betterstreamflix.utils.AppLanguageManager
 import com.dskja.betterstreamflix.utils.ArtworkRepairScheduler
 import com.dskja.betterstreamflix.utils.CacheUtils
+import com.dskja.betterstreamflix.utils.DeviceCapabilities
 import com.dskja.betterstreamflix.utils.DnsResolver
 import com.dskja.betterstreamflix.utils.IsrgRootTrustProvider
 import com.dskja.betterstreamflix.utils.TMDb3
@@ -69,31 +70,40 @@ class BetterStreamflixApp : Application() {
             }
         })
 
-        // 0. Initialize Conscrypt for modern SSL on old Android
-        Security.insertProviderAt(Conscrypt.newProvider(), 1)
+        // 0. Initialize Conscrypt for modern SSL on old Android.
+        // Fire OS / low-RAM sticks can fail loading native Conscrypt — never abort startup.
+        runCatching {
+            Security.insertProviderAt(Conscrypt.newProvider(), 1)
+        }.onFailure {
+            android.util.Log.e("BetterStreamflixApp", "Conscrypt init failed: ${it.message}")
+        }
 
         // 1. Install ISRG Root X1 globally for Let's Encrypt. On Android < 7 (API 24)
         // network_security_config.xml is not supported so the certificate must be injected manually.
-        IsrgRootTrustProvider.install()
+        runCatching { IsrgRootTrustProvider.install() }
 
         // 2. Inizializzazione preferenze (con applicationContext)
         UserPreferences.setup(this)
         DnsResolver.setDnsUrl(UserPreferences.dohProviderUrl)
         // Rebuild after DoH is applied so the first TMDB call never uses system DNS.
-        TMDb3.rebuildService()
+        runCatching { TMDb3.rebuildService() }
 
         val appContext = applicationContext
         val isTv = packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
         val threshold = if (isTv) 10L else 50L
 
         applicationScope.launch(Dispatchers.IO) {
-            AppDatabase.setup(appContext)
-            SupabaseProvider.initialize(appContext)
+            runCatching { AppDatabase.setup(appContext) }
+            runCatching { SupabaseProvider.initialize(appContext) }
             runCatching { CloudSyncManager.initialize(appContext) }
-            SerienStreamProvider.initialize(appContext)
-            AniWorldProvider.initialize(appContext)
-            ArtworkRepairScheduler.schedule(appContext, UserPreferences.currentProvider)
-            CacheUtils.autoClearIfNeeded(appContext, thresholdMb = threshold)
+            runCatching { SerienStreamProvider.initialize(appContext) }
+            runCatching { AniWorldProvider.initialize(appContext) }
+            runCatching { ArtworkRepairScheduler.schedule(appContext, UserPreferences.currentProvider) }
+            // Skip automatic cache wipe on constrained Fire TV sticks: creating a WebView
+            // during cold start can kill the process right after the splash screen.
+            if (!DeviceCapabilities.shouldUseConstrainedPlayback(appContext)) {
+                runCatching { CacheUtils.autoClearIfNeeded(appContext, thresholdMb = threshold) }
+            }
         }
     }
 

--- a/app/src/main/java/com/dskja/betterstreamflix/activities/main/MainMobileActivity.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/activities/main/MainMobileActivity.kt
@@ -104,12 +104,6 @@ class MainMobileActivity : FragmentActivity() {
 
         super.onCreate(savedInstanceState)
 
-        AnimeOnlineNinjaProvider.init(this)
-        Cine24hProvider.init(this)
-        FilmyOnlineCcProvider.init(this)
-        GuardaSerieProvider.init(this)
-        ZaluknijProvider.init(this)
-
         WindowCompat.setDecorFitsSystemWindows(window, false)
         val palette = ThemeManager.palette(UserPreferences.selectedTheme)
         window.statusBarColor = palette.systemBar
@@ -118,6 +112,15 @@ class MainMobileActivity : FragmentActivity() {
         _binding = ActivityMainMobileBinding.inflate(layoutInflater)
         setContentView(binding.root)
         applyThemeNavigationChrome()
+
+        // Defer provider native/WebView setup so splash/first frame can paint first.
+        window.decorView.post {
+            runCatching { AnimeOnlineNinjaProvider.init(this) }
+            runCatching { Cine24hProvider.init(this) }
+            runCatching { FilmyOnlineCcProvider.init(this) }
+            runCatching { GuardaSerieProvider.init(this) }
+            runCatching { ZaluknijProvider.init(this) }
+        }
 
         ViewCompat.setOnApplyWindowInsetsListener(binding.mainContent) { view, windowInsets ->
             val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())

--- a/app/src/main/java/com/dskja/betterstreamflix/activities/main/MainTvActivity.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/activities/main/MainTvActivity.kt
@@ -55,23 +55,17 @@ class MainTvActivity : FragmentActivity() {
         
         super.onCreate(savedInstanceState)
         
-        // Inizializza il provider con il context dell'attività per gestire eventuali bypass visibili
-        AnimeOnlineNinjaProvider.init(this)
-        Cine24hProvider.init(this)
-        FilmyOnlineCcProvider.init(this)
-        ZaluknijProvider.init(this)
-        GuardaSerieProvider.init(this)
-
-        _binding = ActivityMainTvBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        applyThemeNavigationChrome()
+        // Defer heavy provider native/WebView setup — eager Cronet/WebView on Fire Stick
+        // 4K (1st gen / Fire OS 6) was killing the process right after the splash overlay.
+        bindingRootAndChrome()
+        deferProviderInits()
 
         binding.ivSplashOverlay.animate()
             .alpha(0f)
             .setDuration(800)
             .setStartDelay(400)
             .withEndAction {
-                binding.ivSplashOverlay.visibility = View.GONE
+                _binding?.ivSplashOverlay?.visibility = View.GONE
             }
 
         val navHostFragment = this.supportFragmentManager
@@ -178,6 +172,23 @@ class MainTvActivity : FragmentActivity() {
                 }
             }
         })
+    }
+
+    private fun bindingRootAndChrome() {
+        _binding = ActivityMainTvBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        applyThemeNavigationChrome()
+    }
+
+    private fun deferProviderInits() {
+        // Post so the splash/first frame can paint before native libs load.
+        window.decorView.post {
+            runCatching { AnimeOnlineNinjaProvider.init(this) }
+            runCatching { Cine24hProvider.init(this) }
+            runCatching { FilmyOnlineCcProvider.init(this) }
+            runCatching { ZaluknijProvider.init(this) }
+            runCatching { GuardaSerieProvider.init(this) }
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/dskja/betterstreamflix/adapters/viewholders/CategoryViewHolder.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/adapters/viewholders/CategoryViewHolder.kt
@@ -47,11 +47,11 @@ class CategoryViewHolder(
         get() = when (_binding) {
             is ItemCategoryMobileBinding -> _binding.rvCategory
             is ItemCategoryTvBinding -> _binding.hgvCategory
-            is ContentCategorySwiperMobileBinding -> _binding.vpCategorySwiper.javaClass
-                .getDeclaredField("mRecyclerView").let {
-                    it.isAccessible = true
-                    it.get(_binding.vpCategorySwiper) as RecyclerView
-                }
+            is ContentCategorySwiperMobileBinding -> {
+                // Avoid ViewPager2 private-field reflection (NoSuchFieldException: mRecyclerView
+                // after R8/ProGuard or AndroidX updates) — caused release crashes on home.
+                (_binding.vpCategorySwiper.getChildAt(0) as? RecyclerView)
+            }
             else -> null
         }
 

--- a/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -20,14 +20,17 @@ import com.dskja.betterstreamflix.utils.ArtworkRequestHeaders
 import com.dskja.betterstreamflix.utils.NetworkClient
 import com.dskja.betterstreamflix.utils.WebViewResolver
 import com.dskja.betterstreamflix.utils.UserPreferences
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.sync.withLock
+import okhttp3.Request
 import org.json.JSONObject
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -247,13 +250,8 @@ object AnimeOnlineNinjaProvider : Provider, ProviderConfigUrl {
 
     private suspend fun fetchJsonDirect(url: String, referer: String): String? {
         val headers = pageHeaders(referer) + ("Accept" to "application/json,text/plain,*/*")
-        val response = AnimeOnlineNinjaCronetClient.get(
-            context = BetterStreamflixApp.instance,
-            url = url,
-            headers = headers,
-            useCache = false,
-        )
-        val body = response.bodyAsString()
+        val response = fetchHttp(url, headers)
+        val body = response.body
         val trimmed = body.trim()
 
         if (response.isSuccessful &&
@@ -263,14 +261,14 @@ object AnimeOnlineNinjaProvider : Provider, ProviderConfigUrl {
         }
 
         if (requiresClearance(body) || response.finalUrl.contains("/cdn-cgi/", ignoreCase = true)) {
-            Log.w(TAG, "Cronet JSON received a challenge -> url=$url")
+            Log.w(TAG, "JSON received a challenge -> url=$url")
             throw ChallengeRequiredException(
                 message = "AnimeOnline Ninja Cloudflare challenge detected for $url",
                 rejectedClearance = clearanceToken(headers["Cookie"]),
             )
         }
         if (!response.isSuccessful || body.isBlank()) {
-            Log.w(TAG, "Cronet JSON rejected -> code=${response.statusCode} url=$url")
+            Log.w(TAG, "JSON rejected -> code=${response.statusCode} url=$url")
             return null
         }
         return null
@@ -1104,21 +1102,19 @@ object AnimeOnlineNinjaProvider : Provider, ProviderConfigUrl {
     }
 
     private suspend fun resolveServers(embedUrl: String, source: Int, pageUrl: String): List<Video.Server> {
-        val response = AnimeOnlineNinjaCronetClient.get(
-            context = BetterStreamflixApp.instance,
-            url = embedUrl,
-            headers = mapOf(
+        val response = fetchHttp(
+            embedUrl,
+            mapOf(
                 "Referer" to pageUrl,
                 "User-Agent" to NetworkClient.USER_AGENT,
                 "Accept" to "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
                 "Accept-Language" to "es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7",
             ),
-            useCache = false,
         )
         if (!response.isSuccessful) {
-            throw IllegalStateException("Cronet embed HTTP ${response.statusCode}: $embedUrl")
+            throw IllegalStateException("Embed HTTP ${response.statusCode}: $embedUrl")
         }
-        val document = Jsoup.parse(response.bodyAsString(), response.finalUrl)
+        val document = Jsoup.parse(response.body, response.finalUrl)
         val servers = linkedMapOf<String, Video.Server>()
 
         document.select("li[onclick*='go_to_player']").forEachIndexed { index, element ->
@@ -1271,15 +1267,47 @@ object AnimeOnlineNinjaProvider : Provider, ProviderConfigUrl {
 
     fun clearanceCookieForCronet(): String? = currentClearanceCookie()
 
+    private data class HttpPage(
+        val statusCode: Int,
+        val finalUrl: String,
+        val body: String,
+    ) {
+        val isSuccessful: Boolean get() = statusCode in 200..299
+    }
+
+    /** Prefer Cronet when available; fall back to OkHttp on Fire Stick / legacy devices. */
+    private suspend fun fetchHttp(url: String, headers: Map<String, String>): HttpPage {
+        val context = BetterStreamflixApp.instance
+        if (AnimeOnlineNinjaCronetClient.isAvailable(context)) {
+            val response = AnimeOnlineNinjaCronetClient.get(
+                context = context,
+                url = url,
+                headers = headers,
+                useCache = false,
+            )
+            return HttpPage(response.statusCode, response.finalUrl, response.bodyAsString())
+        }
+
+        return withContext(Dispatchers.IO) {
+            val request = Request.Builder()
+                .url(url)
+                .apply { headers.forEach { (name, value) -> header(name, value) } }
+                .get()
+                .build()
+            NetworkClient.default.newCall(request).execute().use { response ->
+                HttpPage(
+                    statusCode = response.code,
+                    finalUrl = response.request.url.toString(),
+                    body = response.body?.string().orEmpty(),
+                )
+            }
+        }
+    }
+
     private suspend fun fetchDocumentDirect(url: String): Document? {
         val headers = pageHeaders(baseUrl)
-        val response = AnimeOnlineNinjaCronetClient.get(
-            context = BetterStreamflixApp.instance,
-            url = url,
-            headers = headers,
-            useCache = false,
-        )
-        val body = response.bodyAsString()
+        val response = fetchHttp(url, headers)
+        val body = response.body
 
         // Cloudflare may append challenge-related scripts or tokenized links to a
         // normal WordPress page. Accept a successful, recognizable provider page
@@ -1292,18 +1320,18 @@ object AnimeOnlineNinjaProvider : Provider, ProviderConfigUrl {
         }
 
         if (requiresClearance(body) || response.finalUrl.contains("/cdn-cgi/", ignoreCase = true)) {
-            Log.w(TAG, "Cronet page received a challenge -> url=${response.finalUrl}")
+            Log.w(TAG, "Page received a challenge -> url=${response.finalUrl}")
             throw ChallengeRequiredException(
                 message = "AnimeOnline Ninja Cloudflare challenge detected for $url",
                 rejectedClearance = clearanceToken(headers["Cookie"]),
             )
         }
         if (!response.isSuccessful || body.isBlank()) {
-            Log.w(TAG, "Cronet page rejected -> code=${response.statusCode} url=$url")
+            Log.w(TAG, "Page rejected -> code=${response.statusCode} url=$url")
             return null
         }
 
-        Log.w(TAG, "Cronet page was incomplete -> url=${response.finalUrl} size=${body.length}")
+        Log.w(TAG, "Page was incomplete -> url=${response.finalUrl} size=${body.length}")
         return null
     }
 

--- a/app/src/main/java/com/dskja/betterstreamflix/ui/AnimeOnlineNinjaCronetUrlLoader.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/ui/AnimeOnlineNinjaCronetUrlLoader.kt
@@ -41,7 +41,8 @@ class AnimeOnlineNinjaCronetUrlLoader(
         height: Int,
         options: Options,
     ): ModelLoader.LoadData<InputStream> {
-        return if (isAnimeOnlineNinja(model)) {
+        val useCronet = isAnimeOnlineNinja(model) && AnimeOnlineNinjaCronetClient.isAvailable(context)
+        return if (useCronet) {
             ModelLoader.LoadData(ObjectKey(model), Fetcher(context, model))
         } else {
             requireNotNull(fallback.buildLoadData(model, width, height, options))

--- a/app/src/main/java/com/dskja/betterstreamflix/utils/AnimeOnlineNinjaCronetClient.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/utils/AnimeOnlineNinjaCronetClient.kt
@@ -1,6 +1,8 @@
 package com.dskja.betterstreamflix.utils
 
 import android.content.Context
+import android.os.Build
+import android.util.Log
 import android.webkit.CookieManager
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.chromium.net.CronetEngine
@@ -16,8 +18,12 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 object AnimeOnlineNinjaCronetClient {
+    private const val TAG = "AnimeNinjaCronet"
     private const val CACHE_SIZE_BYTES = 20L * 1024L * 1024L
     private const val READ_BUFFER_SIZE = 32 * 1024
+
+    @Volatile
+    private var engineUnavailable = false
 
     data class Response(
         val statusCode: Int,
@@ -58,8 +64,28 @@ object AnimeOnlineNinjaCronetClient {
         Thread(runnable, "anime-ninja-cronet").apply { isDaemon = true }
     }
 
+    /**
+     * Soft init only — never force-load native Cronet during Activity.onCreate.
+     * Eager CronetEngine.build() was crashing Fire Stick 4K (1st gen) right after splash.
+     */
     fun init(context: Context) {
-        engine(context)
+        // Intentionally no-op for cold start. Engine is created lazily on first request.
+        if (DeviceCapabilities.shouldUseConstrainedPlayback(context) ||
+            Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1
+        ) {
+            Log.i(TAG, "Deferring Cronet engine creation on constrained/legacy device")
+        }
+    }
+
+    fun isAvailable(context: Context): Boolean {
+        if (engineUnavailable) return false
+        // Fire Stick / Android 7.1: skip Cronet entirely — native load can abort the process.
+        if (DeviceCapabilities.shouldUseConstrainedPlayback(context) ||
+            Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1
+        ) {
+            return false
+        }
+        return runCatching { engineOrNull(context) != null }.getOrDefault(false)
     }
 
     suspend fun get(
@@ -90,6 +116,12 @@ object AnimeOnlineNinjaCronetClient {
             if (!call.isCancelled() && completed.compareAndSet(false, true)) {
                 callback.onComplete(result)
             }
+        }
+
+        val cronet = engineOrNull(context)
+        if (cronet == null) {
+            complete(Result.failure(IllegalStateException("Cronet unavailable on this device")))
+            return call
         }
 
         val requestCallback = object : UrlRequest.Callback() {
@@ -145,7 +177,7 @@ object AnimeOnlineNinjaCronetClient {
             override fun onCanceled(request: UrlRequest, info: UrlResponseInfo?) = Unit
         }
 
-        val builder = engine(context).newUrlRequestBuilder(url, requestCallback, executor)
+        val builder = cronet.newUrlRequestBuilder(url, requestCallback, executor)
             .setHttpMethod("GET")
         if (!useCache) builder.disableCache()
         headers.forEach { (name, value) ->
@@ -158,16 +190,32 @@ object AnimeOnlineNinjaCronetClient {
     }
 
     @Synchronized
-    private fun engine(context: Context): CronetEngine {
+    private fun engineOrNull(context: Context): CronetEngine? {
+        if (engineUnavailable) return null
         engine?.let { return it }
-        return CronetEngine.Builder(context.applicationContext)
-            .enableHttp2(true)
-            .enableQuic(true)
-            .enableBrotli(true)
-            .setStoragePath(context.cacheDir.resolve("anime-ninja-cronet").apply { mkdirs() }.absolutePath)
-            .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_DISK, CACHE_SIZE_BYTES)
-            .build()
-            .also { engine = it }
+        val appContext = context.applicationContext
+        if (DeviceCapabilities.shouldUseConstrainedPlayback(appContext) ||
+            Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1
+        ) {
+            engineUnavailable = true
+            return null
+        }
+        return try {
+            CronetEngine.Builder(appContext)
+                .enableHttp2(true)
+                .enableQuic(true)
+                .enableBrotli(true)
+                .setStoragePath(
+                    appContext.cacheDir.resolve("anime-ninja-cronet").apply { mkdirs() }.absolutePath
+                )
+                .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_DISK, CACHE_SIZE_BYTES)
+                .build()
+                .also { engine = it }
+        } catch (t: Throwable) {
+            engineUnavailable = true
+            Log.e(TAG, "CronetEngine unavailable: ${t.message}")
+            null
+        }
     }
 
     private fun persistCookies(info: UrlResponseInfo) {

--- a/app/src/main/mobile/AndroidManifest.xml
+++ b/app/src/main/mobile/AndroidManifest.xml
@@ -30,6 +30,7 @@
         android:name=".BetterStreamflixApp"
         android:allowBackup="true"
         android:banner="@mipmap/ic_banner"
+        android:extractNativeLibs="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:logo="@mipmap/ic_launcher"

--- a/app/src/main/tv/AndroidManifest.xml
+++ b/app/src/main/tv/AndroidManifest.xml
@@ -27,6 +27,7 @@
         android:name=".BetterStreamflixApp"
         android:allowBackup="true"
         android:banner="@mipmap/ic_banner"
+        android:extractNativeLibs="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:logo="@mipmap/ic_launcher"


### PR DESCRIPTION
## Summary
Addresses the Fire Stick 4K (1st gen) report: splash screen shows, then the app exits immediately when opening the v1.0.0 APK from GitHub.

Likely causes on Fire OS 6 (Android 7.1):
- Eager `CronetEngine` / Conscrypt native load during `MainTvActivity.onCreate`
- WebView creation during automatic cache wipe on cold start
- Compressed in-APK JNI libs not loading on older Fire OS
- ViewPager2 `mRecyclerView` reflection (release home crash)

## Changes
- Soft-fail Conscrypt / background DB init; skip auto cache WebView wipe on Fire/low-RAM
- Defer provider inits until after first frame; never load Cronet on Fire Stick / API ≤ 25 (OkHttp fallback for Anime Online Ninja)
- `extractNativeLibs=true` + `useLegacyPackaging` for JNI
- Replace ViewPager2 private-field reflection with `getChildAt(0)`

## Test plan
- [ ] Install release APK on Fire Stick 4K 1st gen — app should pass splash and reach provider list
- [ ] Smoke on a modern Android TV / phone that Cronet still works for Anime Online Ninja images
- [ ] CI Build & Release APK green