### PR TITLE
fix: Download-Zahnrad nicht mehr von Suchlupe verdeckt

### DIFF
--- a/app/src/main/java/com/dskja/betterstreamflix/activities/main/MainMobileActivity.kt
+++ b/app/src/main/java/com/dskja/betterstreamflix/activities/main/MainMobileActivity.kt
@@ -319,10 +319,14 @@ class MainMobileActivity : FragmentActivity() {
         val showBottomNav =
             UserPreferences.currentProvider != null && isTopLevelProviderDestination(destinationId)
         binding.bnvMain.visibility = if (showBottomNav) View.VISIBLE else View.GONE
+        // Hide on search (already there), downloads, and settings so local header
+        // actions (e.g. downloads gear) are not covered by the floating search FAB.
         binding.btnMainSearch.visibility = if (
             UserPreferences.currentProvider != null &&
             isTopLevelProviderDestination(destinationId) &&
-            destinationId != R.id.search
+            destinationId != R.id.search &&
+            destinationId != R.id.downloads &&
+            destinationId != R.id.settings
         ) View.VISIBLE else View.GONE
         runCatching {
             val mini = binding.root.findViewById<View>(R.id.cast_mini_controller)


### PR DESCRIPTION
## Problem
Im Download-Tab überlagert die schwebende Suchlupe (`btn_main_search`) oben rechts das Zahnrad (`btn_downloads_menu`), sodass es nicht sichtbar/bedienbar ist.

## Fix
Suchlupe auf den Tabs **Downloads** und **Settings** ausblenden (wie bereits auf Search). Dort brauchen lokale Header-Aktionen die Ecke oben rechts.

## Test
- Download-Tab öffnen → Zahnrad sichtbar und tippbar
- Home/Movies/Series → Suchlupe weiterhin sichtbar
- Settings-Tab → keine überlagernde Suchlupe